### PR TITLE
Updates 2.1.0 efgh

### DIFF
--- a/pipeline/scripts/13-excelExport.R
+++ b/pipeline/scripts/13-excelExport.R
@@ -70,7 +70,7 @@ tmp <- cbind(tmp, "HMDB_name"=tmp.hmdb_name.pos)
 outlist <- rbind(tmp, tmp.pos.left, tmp.neg.left)
 
 # Filter 
-load(hmdb) # rlvnc
+load(hmdb) # rlvnc in global environment
 
 peaksInList <- which(rownames(outlist) %in% rownames(rlvnc))
 outlist <- cbind(outlist[peaksInList,],as.data.frame(rlvnc[rownames(outlist)[peaksInList],]))
@@ -88,8 +88,6 @@ filelist <- "AllPeakGroups"
 
 wb <- createWorkbook("SinglePatient")
 addWorksheet(wb, filelist)
-#outlist.backup <- outlist 
-#outlist <- outlist.backup
 
 # small function for rounding numbers to x digits
 round_df <- function(x, digits) {
@@ -268,7 +266,7 @@ save(IS_pos,IS_neg,IS_summed, file = paste0(outdir, "/", project, '_IS_results.R
 
 
 
-# Barplot voor alle IS
+# Barplot for all IS (interne standaards)
 IS_neg_plot <- ggplot(IS_neg, aes(Sample,Intensity))+
   ggtitle("Interne Standaard (Neg)") +
   geom_bar(aes(fill=HMDB.name),stat='identity')+
@@ -407,7 +405,7 @@ if (z_score == 1) {
   # you need all positive control samples, thus starting the script only if all are available
   if (length(missing_pos) == 0) {
     ### POSITIVE CONTROLS
-    #HMDB codes
+    # make positive control excel with specific HMDB_codes in combination with specific control samples 
     PA_codes <- c('HMDB00824', 'HMDB00783', 'HMDB00123')
     PKU_codes <- c('HMDB00159')
     LPI_codes <- c('HMDB00904', 'HMDB00641', 'HMDB00182')
@@ -425,29 +423,17 @@ if (z_score == 1) {
     colnames(LPI_data) <- c('HMDB.code','HMDB.name','Sample','Zscore')
     
     Pos_Contr <- rbind(PA_data, PKU_data, LPI_data)
-    #Pos_Contr <- rbind(PA_data)
+    #Pos_Contr <- rbind(PA_data) #old code, does not add all dataframes together, above is new
     Pos_Contr$Zscore <- as.numeric(Pos_Contr$Zscore)
+    # extra information added to excel for future reference. made in beginning of this script
     Pos_Contr$Matrix <- matrix
     Pos_Contr$Rundate <- rundate
     Pos_Contr$Project <- project
     
     #Save results
     save(Pos_Contr,file = paste0(outdir, "/", project, '_Pos_Contr.RData'))
-    Pos_Contr$Zscore <- round_df(Pos_Contr$Zscore, 2)
+    Pos_Contr$Zscore <- round_df(Pos_Contr$Zscore, 2) # asked by Lab to round the number to 2 digits
     write.xlsx(Pos_Contr, file = paste0(outdir, "/", project, '_Pos_Contr.xlsx'), sheetName = "Sheet1", col.names = TRUE, row.names = TRUE, append = FALSE)
-    
-    # make positive control excel with specific HMDB_codes  
-    #exceldata <- read.xlsx(xlsx_name)
-    #pos_contr_excel <- select(exceldata, one_of(c("HMDB_code", "name", "P1002.1_Zscore", "P1003.1_Zscore", "P1005.1_Zscore"))) # "one_of" to accommodate for "invalid" column names (if not existing)
-    #pos_contr_excel$Matrix <- matrix
-    #pos_contr_excel$Rundate <- rundate
-    #pos_contr_excel$Project <- project
-    #setDT(pos_contr_excel)
-    #pos_contr_excel <- melt(pos_contr_excel, measure=patterns("_Zscore$"), value.name = c("Zscore"), variable.name = "Sample")
-    #selected_HMDB_codes <- c('HMDB00824', 'HMDB00783', 'HMDB00123', 'HMDB00159', 'HMDB00904', 'HMDB00641', 'HMDB00182')
-    #pos_contr_excel <- subset(pos_contr_excel, HMDB_code %in% selected_HMDB_codes)
-    #pos_contr_excel$Zscore <- round_df(pos_contr_excel$Zscore, 2)
-    #write.xlsx(pos_contr_excel, file = paste0(outdir, "/", project, '_Pos_Contr.xlsx'), sheetName = "Sheet1", col.names = TRUE, row.names = TRUE, append = FALSE)
     
   } else {
     write.table(missing_pos, file = paste(outdir, "missing_positive_controls.txt", sep = "/"), row.names = FALSE, col.names = FALSE, quote = FALSE)

--- a/pipeline/scripts/13-excelExport.R
+++ b/pipeline/scripts/13-excelExport.R
@@ -435,6 +435,7 @@ if (z_score == 1) {
     pos_contr_excel <- melt(pos_contr_excel, measure=patterns("_Zscore$"), value.name = c("Zscore"), variable.name = "Sample")
     selected_HMDB_codes <- c('HMDB00824', 'HMDB00783', 'HMDB00123', 'HMDB00159', 'HMDB00904', 'HMDB00641', 'HMDB00182')
     pos_contr_excel <- subset(pos_contr_excel, HMDB_code %in% selected_HMDB_codes)
+    pos_contr_excel$Zscore <- round_df(pos_contr_excel$Zscore, 2)
     write.xlsx(pos_contr_excel, file = paste0(outdir, "/", project, '_Pos_Contr.xlsx'), sheetName = "Sheet1", col.names = TRUE, row.names = TRUE, append = FALSE)
     
   } else {

--- a/pipeline/scripts/13-excelExport.R
+++ b/pipeline/scripts/13-excelExport.R
@@ -91,6 +91,16 @@ addWorksheet(wb, filelist)
 #outlist.backup <- outlist 
 #outlist <- outlist.backup
 
+# small function for rounding numbers to x digits
+round_df <- function(x, digits) {
+  # round all numeric variables
+  # x: data frame 
+  # digits: number of digits to round
+  numeric_columns <- sapply(x, mode) == 'numeric'
+  x[numeric_columns] <-  round(x[numeric_columns], digits)
+  x
+}
+
 # Add Z-scores and create plots
 if (z_score == 1) {
   ########## Statistics: Z-score
@@ -423,20 +433,21 @@ if (z_score == 1) {
     
     #Save results
     save(Pos_Contr,file = paste0(outdir, "/", project, '_Pos_Contr.RData'))
+    Pos_Contr$Zscore <- round_df(pos_contr_excel$Zscore, 2)
     write.xlsx(Pos_Contr, file = paste0(outdir, "/", project, '_Pos_Contr.xlsx'), sheetName = "Sheet1", col.names = TRUE, row.names = TRUE, append = FALSE)
     
     # make positive control excel with specific HMDB_codes  
-    exceldata <- read.xlsx(xlsx_name)
-    pos_contr_excel <- select(exceldata, one_of(c("HMDB_code", "name", "P1002.1_Zscore", "P1003.1_Zscore", "P1005.1_Zscore"))) # "one_of" to accommodate for "invalid" column names (if not existing)
-    pos_contr_excel$Matrix <- matrix
-    pos_contr_excel$Rundate <- rundate
-    pos_contr_excel$Project <- project
-    setDT(pos_contr_excel)
-    pos_contr_excel <- melt(pos_contr_excel, measure=patterns("_Zscore$"), value.name = c("Zscore"), variable.name = "Sample")
-    selected_HMDB_codes <- c('HMDB00824', 'HMDB00783', 'HMDB00123', 'HMDB00159', 'HMDB00904', 'HMDB00641', 'HMDB00182')
-    pos_contr_excel <- subset(pos_contr_excel, HMDB_code %in% selected_HMDB_codes)
-    pos_contr_excel$Zscore <- round_df(pos_contr_excel$Zscore, 2)
-    write.xlsx(pos_contr_excel, file = paste0(outdir, "/", project, '_Pos_Contr.xlsx'), sheetName = "Sheet1", col.names = TRUE, row.names = TRUE, append = FALSE)
+    #exceldata <- read.xlsx(xlsx_name)
+    #pos_contr_excel <- select(exceldata, one_of(c("HMDB_code", "name", "P1002.1_Zscore", "P1003.1_Zscore", "P1005.1_Zscore"))) # "one_of" to accommodate for "invalid" column names (if not existing)
+    #pos_contr_excel$Matrix <- matrix
+    #pos_contr_excel$Rundate <- rundate
+    #pos_contr_excel$Project <- project
+    #setDT(pos_contr_excel)
+    #pos_contr_excel <- melt(pos_contr_excel, measure=patterns("_Zscore$"), value.name = c("Zscore"), variable.name = "Sample")
+    #selected_HMDB_codes <- c('HMDB00824', 'HMDB00783', 'HMDB00123', 'HMDB00159', 'HMDB00904', 'HMDB00641', 'HMDB00182')
+    #pos_contr_excel <- subset(pos_contr_excel, HMDB_code %in% selected_HMDB_codes)
+    #pos_contr_excel$Zscore <- round_df(pos_contr_excel$Zscore, 2)
+    #write.xlsx(pos_contr_excel, file = paste0(outdir, "/", project, '_Pos_Contr.xlsx'), sheetName = "Sheet1", col.names = TRUE, row.names = TRUE, append = FALSE)
     
   } else {
     write.table(missing_pos, file = paste(outdir, "missing_positive_controls.txt", sep = "/"), row.names = FALSE, col.names = FALSE, quote = FALSE)

--- a/pipeline/scripts/13-excelExport.R
+++ b/pipeline/scripts/13-excelExport.R
@@ -330,8 +330,8 @@ IS_neg_select_barplot <- ggplot(subset(IS_neg, HMDB.name %in% IS_neg_selection),
   geom_bar(aes(fill=HMDB.name),stat='identity')+
   labs(x='',y='Intensity')+
   facet_wrap(~HMDB.name, scales='free', ncol = 2)+
-  theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=8), legend.position='none')+
-  scale_y_continuous(breaks = scales::pretty_breaks(n = 10))
+  theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=8), legend.position='none')
+scale_y_continuous(breaks = scales::pretty_breaks(n = 10))
 IS_pos_select_barplot <- ggplot(subset(IS_pos, HMDB.name %in% IS_pos_selection), aes(Sample,Intensity)) +
   ggtitle("Interne Standaard (Pos)") +
   geom_bar(aes(fill=HMDB.name),stat='identity')+
@@ -347,10 +347,10 @@ IS_sum_select_barplot <- ggplot(subset(IS_summed, HMDB.name %in% IS_sum_selectio
   theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=8), legend.position='none')+
   scale_y_continuous(breaks = scales::pretty_breaks(n = 10))
 
-w <- 4 + 0.2 * len
-ggsave(paste0(outdir, "/plots/IS_bar_select_neg.png"), plot = IS_neg_select_barplot, height = w/2.5, width = w, units = "in")
-ggsave(paste0(outdir, "/plots/IS_bar_select_pos.png"), plot = IS_pos_select_barplot, height = w/2.5, width = w, units = "in")
-ggsave(paste0(outdir, "/plots/IS_bar_select_sum.png"), plot = IS_sum_select_barplot, height = w/2.5, width = w, units = "in")
+w <- 9 + 0.35 * len
+ggsave(paste0(outdir, "/plots/IS_bar_select_neg.png"), plot = IS_neg_select_barplot, height = w/2.0, width = w, units = "in")
+ggsave(paste0(outdir, "/plots/IS_bar_select_pos.png"), plot = IS_pos_select_barplot, height = w/2.0, width = w, units = "in")
+ggsave(paste0(outdir, "/plots/IS_bar_select_sum.png"), plot = IS_sum_select_barplot, height = w/2.0, width = w, units = "in")
 
 
 # Lineplot voor selectie aan interne standaarden voor alle data
@@ -359,28 +359,27 @@ IS_neg_select_lineplot <- ggplot(subset(IS_neg, HMDB.name %in% IS_neg_selection)
   geom_point(aes(col=HMDB.name))+
   geom_line(aes(col=HMDB.name, group=HMDB.name))+
   labs(x='',y='Intensity')+
-  theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=10))+
+  theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=8))+
   scale_y_continuous(breaks = scales::pretty_breaks(n = 10))
 IS_pos_select_lineplot <- ggplot(subset(IS_pos, HMDB.name %in% IS_pos_selection), aes(Sample,Intensity)) +
   ggtitle("Interne Standaard (Pos)") +
   geom_point(aes(col=HMDB.name))+
   geom_line(aes(col=HMDB.name, group=HMDB.name))+
   labs(x='',y='Intensity')+
-  theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=10))+
+  theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=8))+
   scale_y_continuous(breaks = scales::pretty_breaks(n = 10))
 IS_sum_select_lineplot <- ggplot(subset(IS_summed, HMDB.name %in% IS_sum_selection), aes(Sample,Intensity)) +
   ggtitle("Interne Standaard (Sum)") +
   geom_point(aes(col=HMDB.name))+
   geom_line(aes(col=HMDB.name, group=HMDB.name))+
   labs(x='',y='Intensity')+
-  theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=10))+
+  theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=8))+
   scale_y_continuous(breaks = scales::pretty_breaks(n = 10))
 
-w <- 3 + 0.2 * len
+w <- 8 + 0.2 * len
 ggsave(paste0(outdir, "/plots/IS_line_select_neg.png"), plot = IS_neg_select_lineplot, height = w/2.5, width = w, units = "in")
 ggsave(paste0(outdir, "/plots/IS_line_select_pos.png"), plot = IS_pos_select_lineplot, height = w/2.5, width = w, units = "in")
 ggsave(paste0(outdir, "/plots/IS_line_select_sum.png"), plot = IS_sum_select_lineplot, height = w/2.5, width = w, units = "in")
-
 
 
 
@@ -427,7 +426,7 @@ if (z_score == 1) {
     
     #Save results
     save(Pos_Contr,file = paste0(outdir, "/", project, '_Pos_Contr.RData'))
-    
+    write.xlsx(Pos_Contr, file = paste0(outdir, "/", project, '_Pos_Contr.xlsx'), sheetName = "Sheet1", col.names = TRUE, row.names = TRUE, append = FALSE)
   } else {
     write.table(missing_pos, file = paste(outdir, "missing_positive_controls.txt", sep = "/"), row.names = FALSE, col.names = FALSE, quote = FALSE)
   }}

--- a/pipeline/scripts/13-excelExport.R
+++ b/pipeline/scripts/13-excelExport.R
@@ -433,7 +433,7 @@ if (z_score == 1) {
     
     #Save results
     save(Pos_Contr,file = paste0(outdir, "/", project, '_Pos_Contr.RData'))
-    Pos_Contr$Zscore <- round_df(pos_contr_excel$Zscore, 2)
+    Pos_Contr$Zscore <- round_df(Pos_Contr$Zscore, 2)
     write.xlsx(Pos_Contr, file = paste0(outdir, "/", project, '_Pos_Contr.xlsx'), sheetName = "Sheet1", col.names = TRUE, row.names = TRUE, append = FALSE)
     
     # make positive control excel with specific HMDB_codes  

--- a/pipeline/scripts/13-excelExport.R
+++ b/pipeline/scripts/13-excelExport.R
@@ -415,10 +415,7 @@ if (z_score == 1) {
     colnames(LPI_data) <- c('HMDB.code','HMDB.name','Sample','Zscore')
     
     Pos_Contr <- rbind(PA_data, PKU_data, LPI_data)
-    
-    Pos_Contr <- rbind(PA_data)
-    
-    
+    #Pos_Contr <- rbind(PA_data)
     Pos_Contr$Zscore <- as.numeric(Pos_Contr$Zscore)
     Pos_Contr$Matrix <- matrix
     Pos_Contr$Rundate <- rundate
@@ -427,6 +424,19 @@ if (z_score == 1) {
     #Save results
     save(Pos_Contr,file = paste0(outdir, "/", project, '_Pos_Contr.RData'))
     write.xlsx(Pos_Contr, file = paste0(outdir, "/", project, '_Pos_Contr.xlsx'), sheetName = "Sheet1", col.names = TRUE, row.names = TRUE, append = FALSE)
+    
+    # make positive control excel with specific HMDB_codes  
+    exceldata <- read.xlsx(xlsx_name)
+    pos_contr_excel <- select(exceldata, one_of(c("HMDB_code", "name", "P1002.1_Zscore", "P1003.1_Zscore", "P1005.1_Zscore"))) # "one_of" to accommodate for "invalid" column names (if not existing)
+    pos_contr_excel$Matrix <- matrix
+    pos_contr_excel$Rundate <- rundate
+    pos_contr_excel$Project <- project
+    setDT(pos_contr_excel)
+    pos_contr_excel <- melt(pos_contr_excel, measure=patterns("_Zscore$"), value.name = c("Zscore"), variable.name = "Sample")
+    selected_HMDB_codes <- c('HMDB00824', 'HMDB00783', 'HMDB00123', 'HMDB00159', 'HMDB00904', 'HMDB00641', 'HMDB00182')
+    pos_contr_excel <- subset(pos_contr_excel, HMDB_code %in% selected_HMDB_codes)
+    write.xlsx(pos_contr_excel, file = paste0(outdir, "/", project, '_Pos_Contr.xlsx'), sheetName = "Sheet1", col.names = TRUE, row.names = TRUE, append = FALSE)
+    
   } else {
     write.table(missing_pos, file = paste(outdir, "missing_positive_controls.txt", sep = "/"), row.names = FALSE, col.names = FALSE, quote = FALSE)
   }}

--- a/pipeline/scripts/13-excelExport.R
+++ b/pipeline/scripts/13-excelExport.R
@@ -254,7 +254,7 @@ IS_neg$Project <- project
 IS_neg$Intensity <- as.numeric(as.character(IS_neg$Intensity))
 
 # Save results
-save(IS_pos,IS_neg,IS_summed, file = paste(outdir, 'IS_results.RData', sep = "/"))
+save(IS_pos,IS_neg,IS_summed, file = paste0(outdir, "/", project, '_IS_results.RData'))
 
 
 
@@ -264,8 +264,7 @@ IS_neg_plot <- ggplot(IS_neg, aes(Sample,Intensity))+
   geom_bar(aes(fill=HMDB.name),stat='identity')+
   labs(x='',y='Intensity')+
   facet_wrap(~HMDB.name, scales='free_y')+
-  theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=8),
-        legend.position='none')+
+  theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=8), legend.position='none')+
   scale_y_continuous(breaks = scales::pretty_breaks(n = 10))
 
 IS_pos_plot <- ggplot(IS_pos, aes(Sample,Intensity))+
@@ -273,8 +272,7 @@ IS_pos_plot <- ggplot(IS_pos, aes(Sample,Intensity))+
   geom_bar(aes(fill=HMDB.name),stat='identity')+
   labs(x='',y='Intensity')+
   facet_wrap(~HMDB.name, scales='free_y')+
-  theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=8),
-        legend.position='none')+
+  theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=8), legend.position='none')+
   scale_y_continuous(breaks = scales::pretty_breaks(n = 10))
 
 IS_sum_plot <- ggplot(IS_summed, aes(Sample,Intensity))+
@@ -282,17 +280,16 @@ IS_sum_plot <- ggplot(IS_summed, aes(Sample,Intensity))+
   geom_bar(aes(fill=HMDB.name),stat='identity')+
   labs(x='',y='Intensity')+
   facet_wrap(~HMDB.name, scales='free_y')+
-  theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=8),
-        legend.position='none')+
+  theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=8), legend.position='none')+
   scale_y_continuous(breaks = scales::pretty_breaks(n = 10))
 
 
 len <- length(repl.pattern)
 
 w <- 9 + 0.35 * len
-ggsave(paste0(outdir, "/plots/IS_bar_neg.png"), plot=IS_neg_plot, height=w/2.5, width=w, units="in")
-ggsave(paste0(outdir, "/plots/IS_bar_pos.png"), plot=IS_pos_plot, height=w/2.5, width=w, units="in")
-ggsave(paste0(outdir, "/plots/IS_bar_sum.png"), plot=IS_sum_plot, height=w/2.5, width=w, units="in")
+ggsave(paste0(outdir, "/plots/IS_bar_all_neg.png"), plot=IS_neg_plot, height=w/2.5, width=w, units="in")
+ggsave(paste0(outdir, "/plots/IS_bar_all_pos.png"), plot=IS_pos_plot, height=w/2.5, width=w, units="in")
+ggsave(paste0(outdir, "/plots/IS_bar_all_sum.png"), plot=IS_sum_plot, height=w/2.5, width=w, units="in")
 
 
 # Lineplot voor alle IS
@@ -318,37 +315,75 @@ IS_sum_plot <- ggplot(IS_summed, aes(Sample, Intensity)) +
   theme(axis.text.x = element_text(angle = 90, hjust = 1, vjust = 0.5, size = 8))
 
 w <- 8 + 0.2 * len
-ggsave(paste0(outdir,"/plots/IS_line_neg.png"), plot = IS_neg_plot, height = w/2.5, width = w, units = "in")
-ggsave(paste0(outdir,"/plots/IS_line_pos.png"), plot = IS_pos_plot, height = w/2.5, width = w, units = "in")
-ggsave(paste0(outdir,"/plots/IS_line_sum.png"), plot = IS_sum_plot, height = w/2.5, width = w, units = "in")
+ggsave(paste0(outdir,"/plots/IS_line_all_neg.png"), plot = IS_neg_plot, height = w/2.5, width = w, units = "in")
+ggsave(paste0(outdir,"/plots/IS_line_all_pos.png"), plot = IS_pos_plot, height = w/2.5, width = w, units = "in")
+ggsave(paste0(outdir,"/plots/IS_line_all_sum.png"), plot = IS_sum_plot, height = w/2.5, width = w, units = "in")
 
 
-# Barplot voor Leucine voor alle data
-IS_now<-'2H3-Leucine (IS)'
-p1<-ggplot(subset(IS_neg, HMDB.name %in% IS_now), aes(Sample,Intensity)) +
-  ggtitle(paste0(IS_now, " (Neg)")) +
+# Barplot voor selectie aan interne standaarden voor alle data
+IS_sum_selection <- c('2H8-Valine (IS)', '2H3-Leucine (IS)', '2H3-Glutamate (IS)', '2H4_13C5-Arginine (IS)', '13C6-Tyrosine (IS)')
+IS_pos_selection <- c('2H4-Alanine (IS)', '13C6-Phenylalanine (IS)', '2H4_13C5-Arginine (IS)', '2H3-Propionylcarnitine (IS)', '2H9-Isovalerylcarnitine (IS)')
+IS_neg_selection <- c('2H2-Ornithine (IS)', '2H3-Glutamate (IS)', '2H2-Citrulline (IS)', '2H4_13C5-Arginine (IS)', '13C6-Tyrosine (IS)')
+
+IS_neg_select_barplot <- ggplot(subset(IS_neg, HMDB.name %in% IS_neg_selection), aes(Sample,Intensity)) +
+  ggtitle("Interne Standaard (Neg)") +
   geom_bar(aes(fill=HMDB.name),stat='identity')+
-  labs(title='Negative mode',x='',y='Intensity')+
-  theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=10),
-        legend.position='none')
-p2<-ggplot(subset(IS_pos, HMDB.name %in% IS_now), aes(Sample,Intensity)) +
-  ggtitle(paste0(IS_now, " (Pos)")) +
+  labs(x='',y='Intensity')+
+  facet_wrap(~HMDB.name, scales='free', ncol = 2)+
+  theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=8), legend.position='none')+
+  scale_y_continuous(breaks = scales::pretty_breaks(n = 10))
+IS_pos_select_barplot <- ggplot(subset(IS_pos, HMDB.name %in% IS_pos_selection), aes(Sample,Intensity)) +
+  ggtitle("Interne Standaard (Pos)") +
   geom_bar(aes(fill=HMDB.name),stat='identity')+
-  labs(title='Positive mode',x='',y='Intensity')+
-  theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=10),
-        legend.position='none')
-p3<-ggplot(subset(IS_summed, HMDB.name %in% IS_now), aes(Sample,Intensity)) +
-  ggtitle(paste0(IS_now, " (Sum)")) +
+  labs(x='',y='Intensity')+
+  facet_wrap(~HMDB.name, scales='free', ncol = 2)+
+  theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=8), legend.position='none')+
+  scale_y_continuous(breaks = scales::pretty_breaks(n = 10))
+IS_sum_select_barplot <- ggplot(subset(IS_summed, HMDB.name %in% IS_sum_selection), aes(Sample,Intensity)) +
+  ggtitle("Interne Standaard (Sum)") +
   geom_bar(aes(fill=HMDB.name),stat='identity')+
-  labs(title='Adduct sums',x='',y='Intensity')+
-  theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=10),
-        legend.position='none')
+  labs(x='',y='Intensity')+
+  facet_wrap(~HMDB.name, scales='free', ncol = 2)+
+  theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=8), legend.position='none')+
+  scale_y_continuous(breaks = scales::pretty_breaks(n = 10))
+
+w <- 4 + 0.2 * len
+ggsave(paste0(outdir, "/plots/IS_bar_select_neg.png"), plot = IS_neg_select_barplot, height = w/2.5, width = w, units = "in")
+ggsave(paste0(outdir, "/plots/IS_bar_select_pos.png"), plot = IS_pos_select_barplot, height = w/2.5, width = w, units = "in")
+ggsave(paste0(outdir, "/plots/IS_bar_select_sum.png"), plot = IS_sum_select_barplot, height = w/2.5, width = w, units = "in")
+
+
+# Lineplot voor selectie aan interne standaarden voor alle data
+IS_neg_select_lineplot <- ggplot(subset(IS_neg, HMDB.name %in% IS_neg_selection), aes(Sample,Intensity)) +
+  ggtitle("Interne Standaard (Neg)") +
+  geom_point(aes(col=HMDB.name))+
+  geom_line(aes(col=HMDB.name, group=HMDB.name))+
+  labs(x='',y='Intensity')+
+  theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=10))+
+  scale_y_continuous(breaks = scales::pretty_breaks(n = 10))
+IS_pos_select_lineplot <- ggplot(subset(IS_pos, HMDB.name %in% IS_pos_selection), aes(Sample,Intensity)) +
+  ggtitle("Interne Standaard (Pos)") +
+  geom_point(aes(col=HMDB.name))+
+  geom_line(aes(col=HMDB.name, group=HMDB.name))+
+  labs(x='',y='Intensity')+
+  theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=10))+
+  scale_y_continuous(breaks = scales::pretty_breaks(n = 10))
+IS_sum_select_lineplot <- ggplot(subset(IS_summed, HMDB.name %in% IS_sum_selection), aes(Sample,Intensity)) +
+  ggtitle("Interne Standaard (Sum)") +
+  geom_point(aes(col=HMDB.name))+
+  geom_line(aes(col=HMDB.name, group=HMDB.name))+
+  labs(x='',y='Intensity')+
+  theme(axis.text.x=element_text(angle = 90, hjust = 1, vjust = 0.5, size=10))+
+  scale_y_continuous(breaks = scales::pretty_breaks(n = 10))
 
 w <- 3 + 0.2 * len
+ggsave(paste0(outdir, "/plots/IS_line_select_neg.png"), plot = IS_neg_select_lineplot, height = w/2.5, width = w, units = "in")
+ggsave(paste0(outdir, "/plots/IS_line_select_pos.png"), plot = IS_pos_select_lineplot, height = w/2.5, width = w, units = "in")
+ggsave(paste0(outdir, "/plots/IS_line_select_sum.png"), plot = IS_sum_select_lineplot, height = w/2.5, width = w, units = "in")
 
-ggsave(paste0(outdir, "/plots/Leucine_neg.png"), plot = p1, height = w/2.5, width = w, units = "in")
-ggsave(paste0(outdir, "/plots/Leucine_pos.png"), plot = p2, height = w/2.5, width = w, units = "in")
-ggsave(paste0(outdir, "/plots/Leucine_sum.png"), plot = p3, height = w/2.5, width = w, units = "in")
+
+
+
 
 ### POSITIVE CONTROLS CHECK
 # these positive controls need to be in the samplesheet, in order to make the Pos_Contr.RData file
@@ -391,7 +426,8 @@ if (z_score == 1) {
     Pos_Contr$Project <- project
     
     #Save results
-    save(Pos_Contr,file = paste(outdir, 'Pos_Contr.RData', sep = "/"))
+    save(Pos_Contr,file = paste0(outdir, "/", project, '_Pos_Contr.RData'))
+    
   } else {
     write.table(missing_pos, file = paste(outdir, "missing_positive_controls.txt", sep = "/"), row.names = FALSE, col.names = FALSE, quote = FALSE)
   }}


### PR DESCRIPTION
a.	Configureerbare job tijden en memory. Zonder direct de code aan te passen de mogelijkheid bieden om de slurmjob tijd en slurmjob memory aan te passen. Bijvoorbeeld in tijden dat het HPC erg vol zit, om time-out errors te voorkomen of als de ruwe date veel groter is en er meer processing kracht nodig is. 
b.	Checkt of de sample name aan de voorwaarden voldoet, zoals omschreven in de SOP (aMEZ0220) als de Z-score aanstaat
c.	Bugfix van een filtered error probleem die ervoor zorgde dat het script niet helemaal afrondde als alle technical replicates van een sample uitgefilterd worden gedurende de pipeline door slechte/te weinig data.  Bovendien gebeurt dit ook nog verderop in het script als dit plaatsvindt bij de positieve controles ('P1002.1', 'P1003.1', 'P1005.1').
d.	Vermeld in de completion e-mail welke samples en/of positieve controles uitgevallen zijn doordat alle technical replicates uitgefilterd zijn (update c). 
e.	Bij het creëren van de bestanden “Pos_Contr.Rdata” en “IS_results.RData” de projectnaam in naam verwerken (unieke naamgeving). Vergelijkbaar als nu al met de Excel file gedaan wordt. Veranderd naar “[Run_name]_Pos_Contr.RData” en “[Run_name]_ IS_results.RData”.
f.	De Leucine plots “Leucine_sum.png”, “Leucine_pos.png” en “Leucine_neg.png” zijn komen te vervallen.
g.	Er zijn extra plots die de meest belangrijke (selectie) Interne standaarden (IS-plots) laat zien per modus. (“IS_bar_select_sum.png“, “IS_bar_select_pos.png“, “IS_bar_select_neg.png“) en de bestaande plots waar alle IS getoond worden zijn hernoemd naar “IS_bar_all_sum.png“, “IS_bar_all_pos.png“, “IS_bar_all_neg.png“. Zie tabel hieronder.
![Screenshot 2020-11-25 at 10 43 06](https://user-images.githubusercontent.com/31845711/100210202-05992380-2f0b-11eb-9512-778320681f60.png)
h.	Punt g kan precies hetzelfde toegepast worden voor de line plots. Er zijn extra plots die de meest belangrijke (selectie) Interne standaarden (IS-plots) laat zien per modus. (“IS_line_select_sum.png“, “IS_line_select_pos.png“, “IS_line_select_neg.png“) en de bestaande plots waar alle IS getoond worden zijn hernoemd naar “IS_line_all_sum.png“, “IS_line_all_pos.png“, “IS_line_all_neg.png“. Zie tabel hierboven, waarbij het woord “bar” vervangen kan worden door “line”.
i.	Een nieuwe excelfile “[Run_name]_Pos_Contr.xlsx”, waarin de Z-scores staan van de positieve controles, Run name, gebruikte matrix en run date. Een voorbeeld in de afbeelding hieronder. 
![Screenshot 2020-11-25 at 10 41 53](https://user-images.githubusercontent.com/31845711/100210098-de425680-2f0a-11eb-8afe-9780a22e8a42.png)