### PR TITLE
fixes issue in GUI with new patient samplenames

### DIFF
--- a/GUI/src/server.R
+++ b/GUI/src/server.R
@@ -110,7 +110,7 @@ function(input, output, session) {
         wrong_t_rep_count = TRUE
       }
       # check 10 : if name fits requirements ( + -> 1 or more, * -> 0 or more)
-      if (grepl("^(?:(?!(C|P))[a-zA-Z0-9]+_{1})?(C|P){1}[0-9]+\\.([1-9]\\d*)+", b_rep, perl = TRUE) != TRUE) {
+      if (grepl("^(?:(?!(C|P))[a-zA-Z0-9]+_{1})?(C|P){1}[0-9]+M*[0-9]+\\.([1-9]\\d*)+", b_rep, perl = TRUE) != TRUE) {
         wrong_samplenames <- c(b_rep, wrong_samplenames)
       }
     }


### PR DESCRIPTION
in GUI there is a check if the sample names are correct if the Z_score is enabled.
This check did not take into account the new format for sample names. This is the fix. This will ensure both the old and the new sample names are possible