### PR TITLE
fix for Px.x samples GUI. tested with 190 samplenames

### DIFF
--- a/GUI/src/server.R
+++ b/GUI/src/server.R
@@ -110,7 +110,7 @@ function(input, output, session) {
         wrong_t_rep_count = TRUE
       }
       # check 10 : if name fits requirements ( + -> 1 or more, * -> 0 or more)
-      if (grepl("^(?:(?!(C|P))[a-zA-Z0-9]+_{1})?(C|P){1}[0-9]+M*[0-9]+\\.([1-9]\\d*)+", b_rep, perl = TRUE) != TRUE) {
+      if (grepl("^(?:(?!(C|P))[a-zA-Z0-9]+_{1})?(C|P){1}[0-9]+M*[0-9]*\\.([1-9]\\d*)+", b_rep, perl = TRUE) != TRUE) {
         wrong_samplenames <- c(b_rep, wrong_samplenames)
       }
     }


### PR DESCRIPTION
First fix had an oversight where samples like P7.7 would not go through the GUI. because of the "+"(=1 or more times) in the second part of the regular expression (number after the optional "M"). this oversight caused the regular expression to expect at least two numbers after a C or P (Pxx.x, where x stands for a number). changed the "+" to an "*"(=0 or more times) to remedy this, which implies that there should be at least one number after the C or P.
To ensure not another oversight was made, I took all sample names of three different old runs. 2 runs according to the old naming format (example: P35.1) and one with the new naming format (example: P2021M00935.1). Script to run is shown below. Additionally added some other sample names that could be possible according to the work instructions for this pipeline (example: P0xx.x or something_Px.x).

```
samplenames <- c("C224.1","C184.1","C191.1","C208.1","C187.1","C236.1","C190.1","P044109.1","C194.1","C203.1","P1002.1","C241.1","C205.1","P1005.1","P000997.1","P004367.1","P004366.1","C185.1","C201.1","C212.1","P001814.1","C188.1","C214.1","P001801.1","P278.2","C225.1","P044103.1","C186.1","C233.1","C199.1","C227.1","C204.1","C228.1","C192.1","C230.1","C217.1","C183.1","P1003.1","P044110.1","C237.1","C226.1","C182.1","P001000.1")
samplenames <- c(samplenames, c("C24.1","C22.1","P86.1","P66.1","P97.1","P115.1","C19.1","C2.1","P99.1","P104.1","C9.1","P88.1","P64.1","P122.1","P124.1","P68.1","P1002.1","P126.1","P103.1","P63.1","P112.1","P93.1","P70.1","P98.1","C4.1","C21.1","C1.1","C10.1","C5.1","P82.1","C14.1","P113.1","P117.1","P92.1","P67.1","C18.1","C11.1","C27.1","P89.1","C17.1","C16.1","P106.1","P1003.1","P90.1","P73.1","P96.1","P71.1","C30.1","P91.1","P100.1","P69.1","P119.1","C6.1","P83.1","P78.1","P110.1","P102.1","P95.1","P94.1","C29.1","P84.1","P85.1","C26.1","C13.1","C25.1","C7.1","P116.1","P107.1","P80.1","P108.1","P101.1","C12.1","P109.1","P77.1","P72.1","C28.1","P123.1","P74.1","P87.1","P111.1","P118.1","C3.1","P1005.1","C15.1","C23.1","P79.1","P120.1"))
samplenames <- c(samplenames, c("C34.1","P2021M00935.1","C48.1","C32.1","P2017M00167.1","C129.1","P2021M00803.1","C125.1","P2021M00888.1","C85.1","C71.1","P2021M00890.1","C60.1","P2021M00780.1","P2021M00899.1","P2021M00923.1","P2021M00795.1","C36.1","C39.1","P2021M00842.1","C62.1","C86.1","P2021M00931.1","C119.1","P2021M00830.1","C123.1","P1005.1","P2021M00881.1","C87.1","P2021M00914.1","C118.1","P2021M00902.1","P2021M00851.1","C121.1","C96.1","C76.1","C61.1","P2021M00799.1","C47.1","C113.1","P2017M00168.1","P2021M00771.1","C126.1","C98.1","C70.1","P2021M00910.1","P2021M00832.1","P2021M00768.1","C102.1","P2021M00871.1","C35.1","P1003.1","C50.1","P1002.1","P2021M00917.1","C44.1","C41.1","P2021M00224.1","P2020M07376.1","P2019M07847.1","P2020M00750.1","P2018M07289.1","P2020M00291.1"))
samplenames <- c(samplenames, c("P7.8", "P7.11", "P2021M00935.55", "P002021M00935.55", "something_C48.1", "something_P1002.1", "something_P2021M00215.1", "something_P7.8"))
samplenames <- unique(samplenames)
wrong_samplenames = c()
for (b_rep in samplenames) {
  if (grepl("^(?:(?!(C|P))[a-zA-Z0-9]+_{1})?(C|P){1}[0-9]+M*[0-9]*\\.([1-9]\\d*)+", b_rep, perl = TRUE) != TRUE) {
    wrong_samplenames <- c(b_rep, wrong_samplenames)}
}
print(wrong_samplenames)
```