### PR TITLE
Release/2.2.0

### DIFF
--- a/pipeline/scripts/13-excelExport.R
+++ b/pipeline/scripts/13-excelExport.R
@@ -398,7 +398,7 @@ if (dims_matrix == "DBS"){
   hline.data.sum <- 
     data.frame(z = c(700000, 1250000, 150000, 425000, 300000),
                HMDB.name = IS_sum_selection)
-}
+} 
 
 # function for ggplot theme
 # see bar plots with all IS
@@ -407,23 +407,23 @@ if (dims_matrix == "DBS"){
 IS_neg_selection_barplot <- ggplot(subset(IS_neg, HMDB.name %in% IS_neg_selection), aes(Sample_level, Intensity)) +
   ggtitle("Interne Standaard (Neg)") +
   geom_bar(aes(fill=HMDB.name),stat='identity') +
-  geom_hline(aes(yintercept = z), subset(hline.data.neg, HMDB.name %in% IS_neg$HMDB.name)) + #subset, if some IS have no data, no empty plots will be generated with a line) +
   labs(x='',y='Intensity') +
-  facet_wrap(~HMDB.name, scales='free', ncol = 2)
+  facet_wrap(~HMDB.name, scales='free', ncol = 2) + 
+  if(exists("hline.data.neg")){geom_hline(aes(yintercept = z), subset(hline.data.neg, HMDB.name %in% IS_neg$HMDB.name))} #subset, if some IS have no data, no empty plots will be generated with a line)
 
 IS_pos_selection_barplot <- ggplot(subset(IS_pos, HMDB.name %in% IS_pos_selection), aes(Sample_level, Intensity)) +
   ggtitle("Interne Standaard (Pos)") +
   geom_bar(aes(fill=HMDB.name),stat='identity') +
-  geom_hline(aes(yintercept = z), subset(hline.data.pos, HMDB.name %in% IS_pos$HMDB.name)) + 
   labs(x='',y='Intensity') +
-  facet_wrap(~HMDB.name, scales='free', ncol = 2)
+  facet_wrap(~HMDB.name, scales='free', ncol = 2) +
+  if(exists("hline.data.pos")){geom_hline(aes(yintercept = z), subset(hline.data.pos, HMDB.name %in% IS_pos$HMDB.name))}
 
 IS_sum_selection_barplot <- ggplot(subset(IS_summed, HMDB.name %in% IS_sum_selection), aes(Sample_level, Intensity)) +
   ggtitle("Interne Standaard (Sum)") +
   geom_bar(aes(fill=HMDB.name),stat='identity') +
-  geom_hline(aes(yintercept = z), subset(hline.data.sum, HMDB.name %in% IS_summed$HMDB.name)) + 
   labs(x='',y='Intensity') +
-  facet_wrap(~HMDB.name, scales='free', ncol = 2)
+  facet_wrap(~HMDB.name, scales='free', ncol = 2) +
+  if(exists("hline.data.sum")){geom_hline(aes(yintercept = z), subset(hline.data.sum, HMDB.name %in% IS_summed$HMDB.name))}
 
 # add theme to ggplot functions
 IS_neg_selection_barplot <- theme_IS_bar(IS_neg_selection_barplot) 

--- a/pipeline/scripts/13-excelExport.R
+++ b/pipeline/scripts/13-excelExport.R
@@ -296,7 +296,7 @@ theme_IS_bar <- function(myPlot) {
 IS_neg_bar_plot <- ggplot(IS_neg, aes(Sample_level, Intensity)) +
   ggtitle("Interne Standaard (Neg)") +
   geom_bar(aes(fill=HMDB.name),stat='identity') +
-  labs(x='',y='Intensity')+
+  labs(x='',y='Intensity') +
   facet_wrap(~HMDB.name, scales='free_y')
 
 IS_pos_bar_plot <- ggplot(IS_pos, aes(Sample_level, Intensity)) +
@@ -317,10 +317,10 @@ IS_pos_bar_plot <- theme_IS_bar(IS_pos_bar_plot)
 IS_sum_bar_plot <- theme_IS_bar(IS_sum_bar_plot)
 
 # save plots to disk
-w <- 9 + 0.35 * sample_count
-ggsave(paste0(outdir, "/plots/IS_bar_all_neg.png"), plot=IS_neg_bar_plot, height=w/2.5, width=w, units="in")
-ggsave(paste0(outdir, "/plots/IS_bar_all_pos.png"), plot=IS_pos_bar_plot, height=w/2.5, width=w, units="in")
-ggsave(paste0(outdir, "/plots/IS_bar_all_sum.png"), plot=IS_sum_bar_plot, height=w/2.5, width=w, units="in")
+width <- 9 + 0.35 * sample_count
+ggsave(paste0(outdir, "/plots/IS_bar_all_neg.png"), plot=IS_neg_bar_plot, height=width/2.5, width=width, units="in")
+ggsave(paste0(outdir, "/plots/IS_bar_all_pos.png"), plot=IS_pos_bar_plot, height=width/2.5, width=width, units="in")
+ggsave(paste0(outdir, "/plots/IS_bar_all_sum.png"), plot=IS_sum_bar_plot, height=width/2.5, width=width, units="in")
 
 ##########
 ##### Line plots with all IS
@@ -365,10 +365,10 @@ IS_neg_line_plot <- theme_IS_line(IS_neg_line_plot)
 IS_pos_line_plot <- theme_IS_line(IS_pos_line_plot)
 
 # save plots to disk
-w <- 8 + 0.2 * sample_count
-ggsave(paste0(outdir,"/plots/IS_line_all_neg.png"), plot = IS_neg_line_plot, height = w/2.5, width = w, units = "in")
-ggsave(paste0(outdir,"/plots/IS_line_all_pos.png"), plot = IS_pos_line_plot, height = w/2.5, width = w, units = "in")
-ggsave(paste0(outdir,"/plots/IS_line_all_sum.png"), plot = IS_sum_line_plot, height = w/2.5, width = w, units = "in")
+width <- 8 + 0.2 * sample_count
+ggsave(paste0(outdir,"/plots/IS_line_all_neg.png"), plot = IS_neg_line_plot, height = width/2.5, width = width, units = "in")
+ggsave(paste0(outdir,"/plots/IS_line_all_pos.png"), plot = IS_pos_line_plot, height = width/2.5, width = width, units = "in")
+ggsave(paste0(outdir,"/plots/IS_line_all_sum.png"), plot = IS_sum_line_plot, height = width/2.5, width = width, units = "in")
 
 ##########
 ##### bar plots with a selection of IS
@@ -431,10 +431,10 @@ IS_pos_selection_barplot <- theme_IS_bar(IS_pos_selection_barplot)
 IS_sum_selection_barplot <- theme_IS_bar(IS_sum_selection_barplot) 
 
 # save plots to disk
-w <- 9 + 0.35 * sample_count
-ggsave(paste0(outdir, "/plots/IS_bar_select_neg.png"), plot = IS_neg_selection_barplot, height = w/2.0, width = w, units = "in")
-ggsave(paste0(outdir, "/plots/IS_bar_select_pos.png"), plot = IS_pos_selection_barplot, height = w/2.0, width = w, units = "in")
-ggsave(paste0(outdir, "/plots/IS_bar_select_sum.png"), plot = IS_sum_selection_barplot, height = w/2.0, width = w, units = "in")
+width <- 9 + 0.35 * sample_count
+ggsave(paste0(outdir, "/plots/IS_bar_select_neg.png"), plot = IS_neg_selection_barplot, height = width/2.0, width = width, units = "in")
+ggsave(paste0(outdir, "/plots/IS_bar_select_pos.png"), plot = IS_pos_selection_barplot, height = width/2.0, width = width, units = "in")
+ggsave(paste0(outdir, "/plots/IS_bar_select_sum.png"), plot = IS_sum_selection_barplot, height = width/2.0, width = width, units = "in")
 
 ##########
 ##### line plots with a selection of IS
@@ -468,10 +468,10 @@ IS_pos_selection_lineplot <- theme_IS_line(IS_pos_selection_lineplot)
 IS_sum_selection_lineplot <- theme_IS_line(IS_sum_selection_lineplot)
 
 # save plots to disk
-w <- 8 + 0.2 * sample_count
-ggsave(paste0(outdir, "/plots/IS_line_select_neg.png"), plot = IS_neg_selection_lineplot, height = w/2.5, width = w, units = "in")
-ggsave(paste0(outdir, "/plots/IS_line_select_pos.png"), plot = IS_pos_selection_lineplot, height = w/2.5, width = w, units = "in")
-ggsave(paste0(outdir, "/plots/IS_line_select_sum.png"), plot = IS_sum_selection_lineplot, height = w/2.5, width = w, units = "in")
+width <- 8 + 0.2 * sample_count
+ggsave(paste0(outdir, "/plots/IS_line_select_neg.png"), plot = IS_neg_selection_lineplot, height = width/2.5, width = width, units = "in")
+ggsave(paste0(outdir, "/plots/IS_line_select_pos.png"), plot = IS_pos_selection_lineplot, height = width/2.5, width = width, units = "in")
+ggsave(paste0(outdir, "/plots/IS_line_select_sum.png"), plot = IS_sum_selection_lineplot, height = width/2.5, width = width, units = "in")
 
 
 ### POSITIVE CONTROLS CHECK

--- a/pipeline/scripts/13-excelExport.R
+++ b/pipeline/scripts/13-excelExport.R
@@ -317,10 +317,10 @@ IS_pos_bar_plot <- theme_IS_bar(IS_pos_bar_plot)
 IS_sum_bar_plot <- theme_IS_bar(IS_sum_bar_plot)
 
 # save plots to disk
-width <- 9 + 0.35 * sample_count
-ggsave(paste0(outdir, "/plots/IS_bar_all_neg.png"), plot=IS_neg_bar_plot, height=width/2.5, width=width, units="in")
-ggsave(paste0(outdir, "/plots/IS_bar_all_pos.png"), plot=IS_pos_bar_plot, height=width/2.5, width=width, units="in")
-ggsave(paste0(outdir, "/plots/IS_bar_all_sum.png"), plot=IS_sum_bar_plot, height=width/2.5, width=width, units="in")
+plot_width <- 9 + 0.35 * sample_count
+ggsave(paste0(outdir, "/plots/IS_bar_all_neg.png"), plot=IS_neg_bar_plot, height=plot_width/2.5, width=plot_width, units="in")
+ggsave(paste0(outdir, "/plots/IS_bar_all_pos.png"), plot=IS_pos_bar_plot, height=plot_width/2.5, width=plot_width, units="in")
+ggsave(paste0(outdir, "/plots/IS_bar_all_sum.png"), plot=IS_sum_bar_plot, height=plot_width/2.5, width=plot_width, units="in")
 
 ##########
 ##### Line plots with all IS
@@ -365,10 +365,10 @@ IS_neg_line_plot <- theme_IS_line(IS_neg_line_plot)
 IS_pos_line_plot <- theme_IS_line(IS_pos_line_plot)
 
 # save plots to disk
-width <- 8 + 0.2 * sample_count
-ggsave(paste0(outdir,"/plots/IS_line_all_neg.png"), plot = IS_neg_line_plot, height = width/2.5, width = width, units = "in")
-ggsave(paste0(outdir,"/plots/IS_line_all_pos.png"), plot = IS_pos_line_plot, height = width/2.5, width = width, units = "in")
-ggsave(paste0(outdir,"/plots/IS_line_all_sum.png"), plot = IS_sum_line_plot, height = width/2.5, width = width, units = "in")
+plot_width <- 8 + 0.2 * sample_count
+ggsave(paste0(outdir,"/plots/IS_line_all_neg.png"), plot = IS_neg_line_plot, height = plot_width/2.5, width = plot_width, units = "in")
+ggsave(paste0(outdir,"/plots/IS_line_all_pos.png"), plot = IS_pos_line_plot, height = plot_width/2.5, width = plot_width, units = "in")
+ggsave(paste0(outdir,"/plots/IS_line_all_sum.png"), plot = IS_sum_line_plot, height = plot_width/2.5, width = plot_width, units = "in")
 
 ##########
 ##### bar plots with a selection of IS
@@ -431,10 +431,10 @@ IS_pos_selection_barplot <- theme_IS_bar(IS_pos_selection_barplot)
 IS_sum_selection_barplot <- theme_IS_bar(IS_sum_selection_barplot) 
 
 # save plots to disk
-width <- 9 + 0.35 * sample_count
-ggsave(paste0(outdir, "/plots/IS_bar_select_neg.png"), plot = IS_neg_selection_barplot, height = width/2.0, width = width, units = "in")
-ggsave(paste0(outdir, "/plots/IS_bar_select_pos.png"), plot = IS_pos_selection_barplot, height = width/2.0, width = width, units = "in")
-ggsave(paste0(outdir, "/plots/IS_bar_select_sum.png"), plot = IS_sum_selection_barplot, height = width/2.0, width = width, units = "in")
+plot_width <- 9 + 0.35 * sample_count
+ggsave(paste0(outdir, "/plots/IS_bar_select_neg.png"), plot = IS_neg_selection_barplot, height = plot_width/2.0, width = plot_width, units = "in")
+ggsave(paste0(outdir, "/plots/IS_bar_select_pos.png"), plot = IS_pos_selection_barplot, height = plot_width/2.0, width = plot_width, units = "in")
+ggsave(paste0(outdir, "/plots/IS_bar_select_sum.png"), plot = IS_sum_selection_barplot, height = plot_width/2.0, width = plot_width, units = "in")
 
 ##########
 ##### line plots with a selection of IS
@@ -468,10 +468,10 @@ IS_pos_selection_lineplot <- theme_IS_line(IS_pos_selection_lineplot)
 IS_sum_selection_lineplot <- theme_IS_line(IS_sum_selection_lineplot)
 
 # save plots to disk
-width <- 8 + 0.2 * sample_count
-ggsave(paste0(outdir, "/plots/IS_line_select_neg.png"), plot = IS_neg_selection_lineplot, height = width/2.5, width = width, units = "in")
-ggsave(paste0(outdir, "/plots/IS_line_select_pos.png"), plot = IS_pos_selection_lineplot, height = width/2.5, width = width, units = "in")
-ggsave(paste0(outdir, "/plots/IS_line_select_sum.png"), plot = IS_sum_selection_lineplot, height = width/2.5, width = width, units = "in")
+plot_width <- 8 + 0.2 * sample_count
+ggsave(paste0(outdir, "/plots/IS_line_select_neg.png"), plot = IS_neg_selection_lineplot, height = plot_width/2.5, width = plot_width, units = "in")
+ggsave(paste0(outdir, "/plots/IS_line_select_pos.png"), plot = IS_pos_selection_lineplot, height = plot_width/2.5, width = plot_width, units = "in")
+ggsave(paste0(outdir, "/plots/IS_line_select_sum.png"), plot = IS_sum_selection_lineplot, height = plot_width/2.5, width = plot_width, units = "in")
 
 
 ### POSITIVE CONTROLS CHECK

--- a/pipeline/scripts/13-excelExport.R
+++ b/pipeline/scripts/13-excelExport.R
@@ -386,7 +386,7 @@ if (dims_matrix == "DBS"){
     data.frame(z = c(150000, 3300000, 1750000, 150000, 270000),
                HMDB.name = IS_pos_selection)
   hline.data.sum <- 
-    data.frame(z = c(1300000, 55000, 500000, 1800000, 1400000),
+    data.frame(z = c(1300000, 2500000, 500000, 1800000, 1400000),
                HMDB.name = IS_sum_selection)
 } else if (dims_matrix == "Plasma"){
   hline.data.neg <- 

--- a/pipeline/scripts/AddOnFunctions/generateGaussian.R
+++ b/pipeline/scripts/AddOnFunctions/generateGaussian.R
@@ -1,7 +1,7 @@
 generateGaussian <- function(x,y,resol,plot,scanmode,int.factor,width,height) {
   
   factor=1.5
-  index = which(y==max(y))
+  index = which(y==max(y))[1]
   x=x[index]
   y=y[index]
   mu = x

--- a/pipeline/scripts/AddOnFunctions/getArea.R
+++ b/pipeline/scripts/AddOnFunctions/getArea.R
@@ -9,7 +9,7 @@ getArea <- function(mu,resol,scale,sigma,int.factor){
   #   sigma=sigma1
   
   # avoid too big vector (cannot allocate vector of size ...)
-  if (mu>1000) return(0)
+  if (mu>1200) return(0)
   
   fwhm = getFwhm(mu,resol)
   mzMin = mu - 2*fwhm


### PR DESCRIPTION
DIMS v2.2.0 is een update van de DIMS pipeline, om het gebruik van een grotere massarange mogelijk te maken. Het is nu mogelijk om ook pieken te meten en identificeren, met hogere m/z waarden. In voorgaande versies was dit 70-600 m/z, maar is nu mogelijk met 70-1050 m/z.  

 

Er is ook een bugfix gedaan, deze had geen implicaties voor de resultaten uit de pipeline. Het betrof een error die altijd in de eindmail en pipeline logs verscheen. Dit was altijd het laatste bestand in de reeks, die geen pieken bevat, en daarom bij 9-runFillMissing een error gaf. Deze kan alleen ruisdata vullen als er pieken gevonden zijn in minstens 1 sample. Het laatste bestand betrof altijd een te kleine massarange waar geen pieken geïdentificeerd werden. Deze bug kwam soms ook wel eens voor in de hogere massaranges (>600), omdat hier simpelweg minder pieken geïdentificeerd kunnen worden. Deze error verschijnt nu niet meer, omdat lege piekranges gecontroleerd en overgeslagen worden. 

 

Daarnaast zijn de   visualisaties ter controle van de kwaliteit van de run en/of sample verbetert. 

Minimale intensiteiten worden geplot worden in de IS_bar_select_xxx plots. Dit helpt de gebruiker om te bepalen of de run en/of samples aan de kwaliteitseisen voldoen. Dit werd eerst handmatig gedaan door eerst op te zoeken, wat de minimale intensiteit is per IS, per modus (pos, neg, summed) en per matrix (DBS, Plasma). Door horizontale lijnen in de plot toe te voegen is dit makkelijker te controleren (zie tabel).  

![Picture1](https://user-images.githubusercontent.com/31845711/128337846-4b4eee73-e59c-4ac7-92c4-9d3205574571.png)

In elke plot is de x-as (de samples van de run) hetzelfde gemaakt tussen de modussen (neg, pos, summed). Deze wilde tussen de plots van volgorde verschillen maar zijn nu op volgorde van naturalsort (sample1, sample 2, sample 3, sample10, sample 11) in plaats van alfabetisch dat niet goed gaat met de nummers (sample 1, sample 10, sample 11, sample 2, sample 3). 

Soms viel bij de IS_line_all_xxx plots de legenda gedeeltelijk weg, omdat er te veel waarden (ISen) in de legenda stonden ten opzichte van de lage aantal gemeten samples. Dit komt omdat de grootte en breedte van de grafiek afhankelijk is van het aantal gemeten samples. Deze is qua (letter)grootte nu aangepast, zodat de legenda nu altijd volledig zichtbaar is. 

 

Nieuwe functies: 

- Kan gebruik maken van een groter massabereik. In voorgaande versies was dit 70-600 m/z, maar is nu mogelijk met 70-1050 m/z.  

- Error met 9-runFillMissing is opgelost en zou niet meer moeten verschijnen in de pipeline-eindmail en slurmmails 

 

Update bestaande functies: 

- Functie voor het maken van de IS plots is uitgebreid met horizontale lijnen, die de minimale intensiteit aangeven waaraan een IS aan moet voldoen. Dit is alleen het geval bij de IS_bar_select_xxx plots. Alleen van geselecteerde IS-en is een minimale intensiteit bepaald, omdat deze goede markers zijn voor de kwaliteit van de run. De horizontale lijnen met minimale intensiteit zijn bepaald per IS, per modus (neg, pos en summed) en per matrix (DBS, Plasma). 

- De volgorde van de x-as is in alle grafieken nu gelijk, op basis van naturalsorting. 

- De legenda van de IS_line_all_xxx plots valt niet meer gedeeltelijk weg, bij weinig samples. 

 

De 2 toegevoegde commits: 

1338c877d7b7384e482f650c9d3503fdfcb1fcf1. Is naar aanleiding van Test3. Problemen met de plots als de matrix niet DBS of Plasma was en Z-score=1. De horizontale lijnen zijn niet nodig, buiten DBS of Plasma, maar er verscheen een error i.p.v. dat er geen lijn getekend werd in de Urine run van Test3. Dit is met deze commit ondervangen. Als de matrix zowel geen DBS als geen Plasma is, maak dan de plot zonder minimale intensiteit-lijnen. 

  

69de1fefcb03797419efac0bc056a2cee5d2a21c. Is naar aanleiding van Test2. De uitvoerend analist zag dat de origineel afgesproken waarde voor de minimale intensiteit van Leucine in DBS niet klopte na voortschrijdend inzicht. Deze is naar verzoek naar boven bijgesteld. 