### PR TITLE
hotfix release 2.2.1

### DIFF
--- a/pipeline/run.sh
+++ b/pipeline/run.sh
@@ -168,7 +168,7 @@ done
 job_ids=\${job_ids::-1}
 echo \${job_ids}
 
-sbatch --job-name=1-queueStart_${name} --time=${queue_1_time} --mem=${queue_1_mem} --dependency=afterany:\${job_ids} --output=${outdir}/logs/queue/1-queueStart.o --error=${outdir}/logs/queue/1-queueStart.e ${global_sbatch_parameters} ${outdir}/jobs/queue/1-queueStart.sh
+sbatch --job-name=1-queueStart_${name} --time=${queue_1_time} --mem=${queue_1_mem} --dependency=afterany:\${job_ids}:+10 --output=${outdir}/logs/queue/1-queueStart.o --error=${outdir}/logs/queue/1-queueStart.e ${global_sbatch_parameters} ${outdir}/jobs/queue/1-queueStart.sh
 EOF
 
 # 1-queueStart.sh
@@ -193,7 +193,7 @@ for mzML in ${outdir}/1-data/*.mzML ; do
 
   ${rscript} ${scripts}/2-DIMS.R \$mzML ${outdir} ${trim} ${dims_thresh} ${resol} ${scripts}
   " > ${outdir}/jobs/2-DIMS/\${input}.sh
-  cur_id=\$(sbatch --job-name=2-dims_\${input}_${name} --time=${job_2_time} --mem=${job_2_mem} --dependency=afterok:\${break_id} --output=${outdir}/logs/2-DIMS/\${input}.o --error=${outdir}/logs/2-DIMS/\${input}.e ${global_sbatch_parameters} ${outdir}/jobs/2-DIMS/\${input}.sh)
+  cur_id=\$(sbatch --job-name=2-dims_\${input}_${name} --time=${job_2_time} --mem=${job_2_mem} --dependency=afterok:\${break_id}:+10 --output=${outdir}/logs/2-DIMS/\${input}.o --error=${outdir}/logs/2-DIMS/\${input}.e ${global_sbatch_parameters} ${outdir}/jobs/2-DIMS/\${input}.sh)
   job_ids+="\${cur_id}:"
 done
 job_ids=\${job_ids::-1} # remove last :
@@ -203,11 +203,11 @@ echo "#!/bin/sh
 
 /hpc/local/CentOS7/common/lang/R/3.2.2/bin/Rscript ${scripts}/3-averageTechReplicates.R ${indir} ${outdir} ${nrepl} ${thresh2remove} ${dims_thresh} ${scripts}
 " > ${outdir}/jobs/3-averageTechReplicates/average.sh
-avg_id=\$(sbatch --job-name=3-average_\${input}_${name} --time=${job_3_time} --mem=${job_3_mem} --dependency=afterok:\${job_ids} --output=${outdir}/logs/3-averageTechReplicates/average.o --error=${outdir}/logs/3-averageTechReplicates/average.e ${global_sbatch_parameters} ${outdir}/jobs/3-averageTechReplicates/average.sh)
+avg_id=\$(sbatch --job-name=3-average_\${input}_${name} --time=${job_3_time} --mem=${job_3_mem} --dependency=afterok:\${job_ids}:+10 --output=${outdir}/logs/3-averageTechReplicates/average.o --error=${outdir}/logs/3-averageTechReplicates/average.e ${global_sbatch_parameters} ${outdir}/jobs/3-averageTechReplicates/average.sh)
 
 # start next queue
-sbatch --job-name=2-queuePeakFinding_positive_${name} --time=${queue_2_time} --mem=${queue_2_mem} --dependency=afterok:\${avg_id} --output=${outdir}/logs/queue/2-queuePeakFinding_positive.o --error=${outdir}/logs/queue/2-queuePeakFinding_positive.e ${global_sbatch_parameters} ${outdir}/jobs/queue/2-queuePeakFinding_positive.sh
-sbatch --job-name=2-queuePeakFinding_negative_${name} --time=${queue_2_time} --mem=${queue_2_mem} --dependency=afterok:\${avg_id} --output=${outdir}/logs/queue/2-queuePeakFinding_negative.o --error=${outdir}/logs/queue/2-queuePeakFinding_negative.e ${global_sbatch_parameters} ${outdir}/jobs/queue/2-queuePeakFinding_negative.sh
+sbatch --job-name=2-queuePeakFinding_positive_${name} --time=${queue_2_time} --mem=${queue_2_mem} --dependency=afterok:\${avg_id}:+10 --output=${outdir}/logs/queue/2-queuePeakFinding_positive.o --error=${outdir}/logs/queue/2-queuePeakFinding_positive.e ${global_sbatch_parameters} ${outdir}/jobs/queue/2-queuePeakFinding_positive.sh
+sbatch --job-name=2-queuePeakFinding_negative_${name} --time=${queue_2_time} --mem=${queue_2_mem} --dependency=afterok:\${avg_id}:+10 --output=${outdir}/logs/queue/2-queuePeakFinding_negative.o --error=${outdir}/logs/queue/2-queuePeakFinding_negative.e ${global_sbatch_parameters} ${outdir}/jobs/queue/2-queuePeakFinding_negative.sh
 EOF
 
 # 14-cleanup.sh
@@ -238,6 +238,15 @@ msg+="<hr>"
 msg+="Positive controls warning:<br>"
 msg+="<p>"
 for x in \$(find ${outdir} -name "positive_controls_warning.txt" -not -empty); do
+  msg+="<b>\${x}</b><br>"
+  msg+=\$(cat \${x})
+  msg+="<br><br>"
+done
+msg+="</p>"
+msg+="<hr>"
+msg+="Missing m/z warning:<br>"
+msg+="<p>"
+for x in \$(find ${outdir} -name "missing_mz_warning.txt" -not -empty); do
   msg+="<b>\${x}</b><br>"
   msg+=\$(cat \${x})
   msg+="<br><br>"
@@ -291,7 +300,7 @@ echo "#!/bin/sh
 
 /hpc/local/CentOS7/common/lang/R/3.2.2/bin/Rscript ${scripts}/5-collectSamples.R ${outdir} ${scanmode}
 " > ${outdir}/jobs/5-collectSamples/${scanmode}.sh
-col_id=\$(sbatch --job-name=5-collectSamples_${scanmode}_${name} --time=${job_5_time} --mem=${job_5_mem} --dependency=afterany:\${job_ids} --output=${outdir}/logs/5-collectSamples/${scanmode}.o --error=${outdir}/logs/5-collectSamples/${scanmode}.e ${global_sbatch_parameters} ${outdir}/jobs/5-collectSamples/${scanmode}.sh)
+col_id=\$(sbatch --job-name=5-collectSamples_${scanmode}_${name} --time=${job_5_time} --mem=${job_5_mem} --dependency=afterany:\${job_ids}:+10 --output=${outdir}/logs/5-collectSamples/${scanmode}.o --error=${outdir}/logs/5-collectSamples/${scanmode}.e ${global_sbatch_parameters} ${outdir}/jobs/5-collectSamples/${scanmode}.sh)
 
 # hmdb_part.R
 echo "#!/bin/sh
@@ -310,7 +319,7 @@ hmdb_id_2=\$(sbatch --job-name=hmdb_part_adductSums_${scanmode}_${name} --time=$
 echo "${hmdb_id_2}" > ${outdir}/logs/hmdb_2
 
 # start next queue
-sbatch --job-name=3-queuePeakGrouping_${scanmode}_${name} --time=${queue_3_time} --mem=${queue_3_mem} --dependency=afterany:\${col_id}:\${hmdb_id_1}:\${hmdb_id_2} --output=${outdir}/logs/queue/3-queuePeakGrouping_${scanmode}.o --error=${outdir}/logs/queue/3-queuePeakGrouping_${scanmode}.e ${global_sbatch_parameters} ${outdir}/jobs/queue/3-queuePeakGrouping_${scanmode}.sh
+sbatch --job-name=3-queuePeakGrouping_${scanmode}_${name} --time=${queue_3_time} --mem=${queue_3_mem} --dependency=afterany:\${col_id}:\${hmdb_id_1}:\${hmdb_id_2}:+10 --output=${outdir}/logs/queue/3-queuePeakGrouping_${scanmode}.o --error=${outdir}/logs/queue/3-queuePeakGrouping_${scanmode}.e ${global_sbatch_parameters} ${outdir}/jobs/queue/3-queuePeakGrouping_${scanmode}.sh
 EOF
 
   # 3-queuePeakGrouping.sh
@@ -335,10 +344,10 @@ echo "#!/bin/sh
 
 /hpc/local/CentOS7/common/lang/R/3.2.2/bin/Rscript ${scripts}/7-collectSamplesGroupedHMDB.R ${outdir} ${scanmode} ${ppm}
 " > ${outdir}/jobs/7-collectSamplesGroupedHMDB/${scanmode}.sh
-col_id=\$(sbatch --job-name=7-collectSamplesGroupedHMDB_${scanmode}_${name} --time=${job_7_time} --mem=${job_7_mem} --dependency=afterany:\${job_ids} --output=${outdir}/logs/7-collectSamplesGroupedHMDB/${scanmode}.o --error=${outdir}/logs/7-collectSamplesGroupedHMDB/${scanmode}.e ${global_sbatch_parameters} ${outdir}/jobs/7-collectSamplesGroupedHMDB/${scanmode}.sh)
+col_id=\$(sbatch --job-name=7-collectSamplesGroupedHMDB_${scanmode}_${name} --time=${job_7_time} --mem=${job_7_mem} --dependency=afterany:\${job_ids}:+10 --output=${outdir}/logs/7-collectSamplesGroupedHMDB/${scanmode}.o --error=${outdir}/logs/7-collectSamplesGroupedHMDB/${scanmode}.e ${global_sbatch_parameters} ${outdir}/jobs/7-collectSamplesGroupedHMDB/${scanmode}.sh)
 
 # start next queue
-sbatch --job-name=4-queuePeakGroupingRest_${scanmode}_${name} --time=${queue_4_time} --mem=${queue_4_mem} --dependency=afterany:\${col_id} --output=${outdir}/logs/queue/4-queuePeakGroupingRest_${scanmode}.o --error=${outdir}/logs/queue/4-queuePeakGroupingRest_${scanmode}.e ${global_sbatch_parameters} ${outdir}/jobs/queue/4-queuePeakGroupingRest_${scanmode}.sh
+sbatch --job-name=4-queuePeakGroupingRest_${scanmode}_${name} --time=${queue_4_time} --mem=${queue_4_mem} --dependency=afterany:\${col_id}:+10 --output=${outdir}/logs/queue/4-queuePeakGroupingRest_${scanmode}.o --error=${outdir}/logs/queue/4-queuePeakGroupingRest_${scanmode}.e ${global_sbatch_parameters} ${outdir}/jobs/queue/4-queuePeakGroupingRest_${scanmode}.sh
 EOF
 
   # 4-queuePeakGroupingRest.sh
@@ -360,7 +369,7 @@ done
 job_ids=\${job_ids::-1}
 
 # start next queue
-sbatch --job-name=5-queueFillMissing_${scanmode}_${name} --time=${queue_5_time} --mem=${queue_5_mem} --dependency=afterany:\${job_ids} --output=${outdir}/logs/queue/5-queueFillMissing_${scanmode}.o --error=${outdir}/logs/queue/5-queueFillMissing_${scanmode}.e ${global_sbatch_parameters} ${outdir}/jobs/queue/5-queueFillMissing_${scanmode}.sh
+sbatch --job-name=5-queueFillMissing_${scanmode}_${name} --time=${queue_5_time} --mem=${queue_5_mem} --dependency=afterany:\${job_ids}:+10 --output=${outdir}/logs/queue/5-queueFillMissing_${scanmode}.o --error=${outdir}/logs/queue/5-queueFillMissing_${scanmode}.e ${global_sbatch_parameters} ${outdir}/jobs/queue/5-queueFillMissing_${scanmode}.sh
 EOF
 
   # 5-queueFillMissing.sh
@@ -398,10 +407,10 @@ echo "#!/bin/sh
 
 /hpc/local/CentOS7/common/lang/R/3.2.2/bin/Rscript ${scripts}/10-collectSamplesFilled.R ${outdir} ${scanmode} ${normalization} ${scripts} ${z_score}  ${ppm}
 " > ${outdir}/jobs/10-collectSamplesFilled/${scanmode}.sh
-col_id=\$(sbatch --job-name=10-collectSamplesFilled_${scanmode}_${name} --time=${job_10_time} --mem=${job_10_mem} --dependency=afterany:\${job_ids} --output=${outdir}/logs/10-collectSamplesFilled/${scanmode}.o --error=${outdir}/logs/10-collectSamplesFilled/${scanmode}.e ${global_sbatch_parameters} ${outdir}/jobs/10-collectSamplesFilled/${scanmode}.sh)
+col_id=\$(sbatch --job-name=10-collectSamplesFilled_${scanmode}_${name} --time=${job_10_time} --mem=${job_10_mem} --dependency=afterany:\${job_ids}:+10 --output=${outdir}/logs/10-collectSamplesFilled/${scanmode}.o --error=${outdir}/logs/10-collectSamplesFilled/${scanmode}.e ${global_sbatch_parameters} ${outdir}/jobs/10-collectSamplesFilled/${scanmode}.sh)
 
 # start next queue
-sbatch --job-name=6-queueSumAdducts_${scanmode}_${name} --time=${queue_6_time} --mem=${queue_6_mem} --dependency=afterany:\${col_id} --output=${outdir}/logs/queue/6-queueSumAdducts_${scanmode}.o --error=${outdir}/logs/queue/6-queueSumAdducts_${scanmode}.e ${global_sbatch_parameters} ${outdir}/jobs/queue/6-queueSumAdducts_${scanmode}.sh
+sbatch --job-name=6-queueSumAdducts_${scanmode}_${name} --time=${queue_6_time} --mem=${queue_6_mem} --dependency=afterany:\${col_id}:+10 --output=${outdir}/logs/queue/6-queueSumAdducts_${scanmode}.o --error=${outdir}/logs/queue/6-queueSumAdducts_${scanmode}.e ${global_sbatch_parameters} ${outdir}/jobs/queue/6-queueSumAdducts_${scanmode}.sh
 EOF
 
   # 6-queueSumAdducts.sh
@@ -427,7 +436,7 @@ echo "#!/bin/sh
 
 /hpc/local/CentOS7/common/lang/R/3.2.2/bin/Rscript ${scripts}/12-collectSamplesAdded.R ${outdir} ${scanmode} ${scripts}
 " > ${outdir}/jobs/12-collectSamplesAdded/${scanmode}.sh
-col_id=\$(sbatch --job-name=12-collectSamplesAdded_${scanmode}_${name} --time=${job_12_time} --mem=${job_12_mem} --dependency=afterany:\${job_ids} --output=${outdir}/logs/12-collectSamplesAdded/${scanmode}.o --error=${outdir}/logs/12-collectSamplesAdded/${scanmode}.e ${global_sbatch_parameters} ${outdir}/jobs/12-collectSamplesAdded/${scanmode}.sh)
+col_id=\$(sbatch --job-name=12-collectSamplesAdded_${scanmode}_${name} --time=${job_12_time} --mem=${job_12_mem} --dependency=afterany:\${job_ids}:+10 --output=${outdir}/logs/12-collectSamplesAdded/${scanmode}.o --error=${outdir}/logs/12-collectSamplesAdded/${scanmode}.e ${global_sbatch_parameters} ${outdir}/jobs/12-collectSamplesAdded/${scanmode}.sh)
 
 if [ -f "${outdir}/logs/done" ]; then   # if one of the scanmodes has already finished
   echo other scanmode already finished queueing - queue next step
@@ -439,8 +448,8 @@ if [ -f "${outdir}/logs/done" ]; then   # if one of the scanmodes has already fi
 
   ${rscript} ${scripts}/13-excelExport.R ${outdir} ${name} ${matrix} ${db2} ${z_score}
   " > ${outdir}/jobs/13-excelExport.sh
-  exp_id=\$(sbatch --job-name=13-excelExport_${name} --time=${job_13_time} --mem=${job_13_mem} --dependency=afterany:\${col_ids} --output=${outdir}/logs/13-excelExport/exp.o --error=${outdir}/logs/13-excelExport/exp.e ${global_sbatch_parameters} ${outdir}/jobs/13-excelExport.sh)
-  sbatch --job-name=14-cleanup_${name} --time=${job_14_time} --mem=${job_14_mem} --dependency=afterany:\${exp_id} --output=${outdir}/logs/14-cleanup.o --error=${outdir}/logs/14-cleanup.e ${global_sbatch_parameters} ${outdir}/jobs/14-cleanup.sh
+  exp_id=\$(sbatch --job-name=13-excelExport_${name} --time=${job_13_time} --mem=${job_13_mem} --dependency=afterany:\${col_ids}:+10 --output=${outdir}/logs/13-excelExport/exp.o --error=${outdir}/logs/13-excelExport/exp.e ${global_sbatch_parameters} ${outdir}/jobs/13-excelExport.sh)
+  sbatch --job-name=14-cleanup_${name} --time=${job_14_time} --mem=${job_14_mem} --dependency=afterany:\${exp_id}:+10 --output=${outdir}/logs/14-cleanup.o --error=${outdir}/logs/14-cleanup.e ${global_sbatch_parameters} ${outdir}/jobs/14-cleanup.sh
 else
   echo other scanmode not queued yet, not yet queueing next step
   echo \${col_id} > ${outdir}/logs/done


### PR DESCRIPTION
Sometimes data seemed to be missing after running the pipeline. This was visible when an IS (internal standard) was missing in the plots.
Seems to be a bigger problem, because there are sometimes chunks of m/z missing in the data, directly related to the HMDB split files by the pipeline.
To fix and monitor this problem, the missing m/z values will be printed to the end mail. An additional file is made for this purpose in each run, namely `missing_mz_warning.txt`. Already tested on a development branch, but I will run another testrun with this hotfix branch. Will become available on `Y:/Metabolomics/Research Metabolic Diagnostics/Metabolomics Projects/Kwaliteit_Validatie/Validatie Pijplijn/Validatie 2.2.1`