### PR TITLE
Release v2.2.2

### DIFF
--- a/pipeline/run.sh
+++ b/pipeline/run.sh
@@ -235,9 +235,9 @@ for x in \$(find ${outdir} -name "sample_names_nodata.txt" -not -empty); do
 done
 msg+="</p>"
 msg+="<hr>"
-msg+="Missing positive controls:<br>"
+msg+="Positive controls warning:<br>"
 msg+="<p>"
-for x in \$(find ${outdir} -name "missing_positive_controls.txt" -not -empty); do
+for x in \$(find ${outdir} -name "positive_controls_warning.txt" -not -empty); do
   msg+="<b>\${x}</b><br>"
   msg+=\$(cat \${x})
   msg+="<br><br>"

--- a/pipeline/scripts/13-excelExport.R
+++ b/pipeline/scripts/13-excelExport.R
@@ -410,9 +410,9 @@ if (z_score == 1) {
   # find if one or more positive control samples are missing
   missing_pos <- c()
   # any() grep because you get a vector of FALSE's and TRUE's. only one grep match is needed for each positive control
-  if (any(grep("^(P1002\\.)[[:digit:]]+_", positive_controls)) && 
-      any(grep("^(P1003\\.)[[:digit:]]+_", positive_controls)) && 
-      any(grep("^(P1005\\.)[[:digit:]]+_", positive_controls))){
+  if (any(grep("^(P1002\\.)[[:digit:]]+_", positivecontrol_list)) && 
+      any(grep("^(P1003\\.)[[:digit:]]+_", positivecontrol_list)) && 
+      any(grep("^(P1005\\.)[[:digit:]]+_", positivecontrol_list))){
     cat("All three positive controls are present")
   } else {
     missing_pos <- paste0(c("positive controls list is not complete: ", positivecontrol_list), collapse=" ")

--- a/pipeline/scripts/13-excelExport.R
+++ b/pipeline/scripts/13-excelExport.R
@@ -408,17 +408,17 @@ positivecontrol_list <- column_list[positive_controls_index]
 
 if (z_score == 1) {
   # find if one or more positive control samples are missing
-  missing_pos <- c()
+  pos_contr_warning <- c()
   # any() grep because you get a vector of FALSE's and TRUE's. only one grep match is needed for each positive control
   if (any(grep("^(P1002\\.)[[:digit:]]+_", positivecontrol_list)) && 
       any(grep("^(P1003\\.)[[:digit:]]+_", positivecontrol_list)) && 
       any(grep("^(P1005\\.)[[:digit:]]+_", positivecontrol_list))){
     cat("All three positive controls are present")
   } else {
-    missing_pos <- paste0(c("positive controls list is not complete: ", positivecontrol_list), collapse=" ")
+    pos_contr_warning <- paste0(c("positive controls list is not complete. Only ", positivecontrol_list, " is/are present"), collapse=" ")
   }
   # you need all positive control samples, thus starting the script only if all are available
-  if (length(missing_pos) == 0) {
+  if (length(pos_contr_warning) == 0) {
     ### POSITIVE CONTROLS
     # make positive control excel with specific HMDB_codes in combination with specific control samples
     PA_sample_name <- positivecontrol_list[grepl("P1002", positivecontrol_list)] #P1001.x_Zscore
@@ -455,7 +455,7 @@ if (z_score == 1) {
     write.xlsx(Pos_Contr, file = paste0(outdir, "/", project, '_Pos_Contr.xlsx'), sheetName = "Sheet1", col.names = TRUE, row.names = TRUE, append = FALSE)
     
   } else {
-    write.table(missing_pos, file = paste(outdir, "missing_positive_controls.txt", sep = "/"), row.names = FALSE, col.names = FALSE, quote = FALSE)
+    write.table(pos_contr_warning, file = paste(outdir, "positive_controls_warning.txt", sep = "/"), row.names = FALSE, col.names = FALSE, quote = FALSE)
   }}
 
 


### PR DESCRIPTION
bugfix missing m/z values
things changed:
- add extra time of 5 seconds after each dependency (wait for this joblist + 5 seconds)
- added in the end mail information about which m/z values are missing or if everything is ok. I want to keep this for a while, to test if the bugfix is consistent. This bug is difficult to reproduce.
- changed afterany to afterok in dependencies
- added 2 wait in bash
- fixed a typo, that filled a variable with job_ids that is never referenced in the code. Therefore the next sbatch took the wrong job_id dependency
