### PR TITLE
Refactor sum adducts

### DIFF
--- a/DIMS.config
+++ b/DIMS.config
@@ -1,13 +1,13 @@
 params {
     scripts_dir = "$projectDir/CustomModules/DIMS/Utils/" 
     tools_dir = "/hpc/dbg_mz/tools/db"
-    hmdb_db_file = "$params.tools_dir/HMDB_V5/HMDB_V5_iso_adducts_IS_test.RData"
-    relevance_file = "$params.tools_dir/HMDB_V5/HMDB_V5_iso_adducts_IS_rlvnc_test.RData"
+    hmdb_db_file = "$params.tools_dir/HMDB_V5/HMDB_V5_iso_adducts_IS.RData"
+    relevance_file = "$params.tools_dir/HMDB_V5/HMDB_V5_iso_adducts_IS_rlvnc.RData"
     hmdb_parts_files = "$params.tools_dir/HMDB_V5/hmdb_parts/"
     sst_components_file = "$params.tools_dir/SST_componenten.txt"
     path_metabolite_groups = "$params.tools_dir/HMDB_V5/metabolite_groups"
-    file_ratios_metabolites = "$params.tools_dir/HMDB_V5/Ratios_between_metabolites_test.csv"
-    file_expected_biomarkers_IEM = "$params.tools_dir/HMDB_V5/Expected_biomarkers_IEM_V5_test.csv"
+    file_ratios_metabolites = "$params.tools_dir/HMDB_V5/Ratios_between_metabolites.csv"
+    file_expected_biomarkers_IEM = "$params.tools_dir/HMDB_V5/Expected_biomarkers_IEM_V5.csv"
     file_explanation = "/hpc/dbg_mz/tools/Explanation_violin_plots.txt"
     file_isomers = "/hpc/dbg_mz/tools/isomers.txt"
     trim = 0.1
@@ -185,8 +185,8 @@ process {
 
     withLabel: SumAdducts {
         cpus = 2
-        memory = { 5.GB * task.attempt }
-        time = { 40.m * task.attempt }
+        memory = { 2.GB * task.attempt }
+        time = { 20.m * task.attempt }
     }
 
     withLabel: ThermoRawFileParser_1_1_11 {

--- a/DIMS.nf
+++ b/DIMS.nf
@@ -135,7 +135,6 @@ workflow {
 
     // Sum adducts of each metabolite per scan mode: identfied part
     SumAdducts(CollectFilled.out.filled_pgrlist, 
-               AverageTechReplicates.out.pattern_files, 
                HMDBparts_main.out.collect().flatten())
 
     // Collect summed adducts parts


### PR DESCRIPTION
The goal was to make this step of the pipeline faster, to tidy up the main script and sum_adducts function and to add unit tests.

main script: CustomModules/DIMS/SumAdducts.R

Actions:
- moved function sum_adducts out of main script into Utils/sum_adducts.R
- removed unnecessary input parameters for function sum_adducts
- added docstrings to function sum_adducts
- writing output to file moved to main script
- function sum_adducts optimized by taking two steps out of while loop
- added unit test in tests/testthat/test_sum_adducts.R

Questions about unit tests; all feedback is welcome.
- is it better to create test objects test_peakgroup_list and test_hmdb_main_part in script or to save them to files and read them in?
- is it necessary to set working directory in testthat.R (at least until functions are in package)?
- are there other tests that need to be added?
  - adducts <- c(1,2) is for positive scan mode, negative scan mode is even simpler (c(1)) and does not need to be tested imho
  - z_score = 0 is only for research, not diagnostics.

Code can be found in /hpc/dbg_mz/development/DIMS_refactor_SumAdducts
