### PR TITLE
Refactor peak grouping

### DIFF
--- a/DIMS.config
+++ b/DIMS.config
@@ -174,7 +174,7 @@ process {
     withLabel: PeakGrouping {
         cpus = 2
         memory = { 2.GB * task.attempt }
-        time = { 80.m * task.attempt }
+        time = { 10.m * task.attempt }
     }
 
     withLabel: SpectrumPeakFinding {

--- a/DIMS.config
+++ b/DIMS.config
@@ -195,35 +195,35 @@ process {
         time = { 5.m * task.attempt }
     }
 
-    withLabel: UnidentifiedCalcZscores {
-        cpus = 2
-        memory = { 10.GB * task.attempt }
-        time = { 10.m * task.attempt }
+//     withLabel: UnidentifiedCalcZscores {
+//         cpus = 2
+//         memory = { 10.GB * task.attempt }
+//         time = { 10.m * task.attempt }
+// 
+//         publishDir {
+//             path = "$params.outdir/Bioinformatics/RData"
+//             mode = 'link'
+//             pattern = '*.RData'
+//         }
+//     }
 
-        publishDir {
-            path = "$params.outdir/Bioinformatics/RData"
-            mode = 'link'
-            pattern = '*.RData'
-        }
-    }
+//     withLabel: UnidentifiedCollectPeaks {
+//         cpus = 2
+//         memory = { 2.GB * task.attempt }
+//         time = { 5.m * task.attempt }
+//     }
 
-    withLabel: UnidentifiedCollectPeaks {
-        cpus = 2
-        memory = { 2.GB * task.attempt }
-        time = { 5.m * task.attempt }
-    }
+//     withLabel: UnidentifiedFillMissing {
+//         cpus = 2
+//         memory = { 10.GB * task.attempt }
+//         time = { 15.m * task.attempt }
+//     }
 
-    withLabel: UnidentifiedFillMissing {
-        cpus = 2
-        memory = { 10.GB * task.attempt }
-        time = { 15.m * task.attempt }
-    }
-
-    withLabel: UnidentifiedPeakGrouping {
-        cpus = 2
-        memory = { 5.GB * task.attempt }
-        time = { 300.m * task.attempt }
-    }
+//     withLabel: UnidentifiedPeakGrouping {
+//         cpus = 2
+//         memory = { 5.GB * task.attempt }
+//         time = { 300.m * task.attempt }
+//     }
 
     withLabel: VersionLog {
         cpus = 2

--- a/DIMS.config
+++ b/DIMS.config
@@ -196,36 +196,6 @@ process {
         time = { 5.m * task.attempt }
     }
 
-//     withLabel: UnidentifiedCalcZscores {
-//         cpus = 2
-//         memory = { 10.GB * task.attempt }
-//         time = { 10.m * task.attempt }
-// 
-//         publishDir {
-//             path = "$params.outdir/Bioinformatics/RData"
-//             mode = 'link'
-//             pattern = '*.RData'
-//         }
-//     }
-
-//     withLabel: UnidentifiedCollectPeaks {
-//         cpus = 2
-//         memory = { 2.GB * task.attempt }
-//         time = { 5.m * task.attempt }
-//     }
-
-//     withLabel: UnidentifiedFillMissing {
-//         cpus = 2
-//         memory = { 10.GB * task.attempt }
-//         time = { 15.m * task.attempt }
-//     }
-
-//     withLabel: UnidentifiedPeakGrouping {
-//         cpus = 2
-//         memory = { 5.GB * task.attempt }
-//         time = { 300.m * task.attempt }
-//     }
-
     withLabel: VersionLog {
         cpus = 2
         memory = { 1.GB * task.attempt }

--- a/DIMS.config
+++ b/DIMS.config
@@ -1,5 +1,6 @@
 params {
     scripts_dir = "$projectDir/CustomModules/DIMS/Utils/" 
+    preprocessing_scripts_dir = "$projectDir/CustomModules/DIMS/preprocessing/" 
     tools_dir = "/hpc/dbg_mz/tools/db"
     hmdb_db_file = "$params.tools_dir/HMDB_V5/HMDB_V5_iso_adducts_IS.RData"
     relevance_file = "$params.tools_dir/HMDB_V5/HMDB_V5_iso_adducts_IS_rlvnc.RData"
@@ -174,7 +175,7 @@ process {
     withLabel: PeakGrouping {
         cpus = 2
         memory = { 2.GB * task.attempt }
-        time = { 10.m * task.attempt }
+        time = { 15.m * task.attempt }
     }
 
     withLabel: SpectrumPeakFinding {

--- a/DIMS.nf
+++ b/DIMS.nf
@@ -53,6 +53,7 @@ include { PeakFinding } from './CustomModules/DIMS/PeakFinding.nf' params(
     scripts_dir:"$params.scripts_dir"
 )
 include { PeakGrouping } from './CustomModules/DIMS/PeakGrouping.nf' params(
+    scripts_dir:"$params.scripts_dir",
     ppm:"$params.ppm"
 )
 include { SpectrumPeakFinding } from './CustomModules/DIMS/SpectrumPeakFinding.nf'
@@ -60,24 +61,24 @@ include { SumAdducts } from './CustomModules/DIMS/SumAdducts.nf' params(
     scripts_dir:"$params.scripts_dir", 
     zscore:"$params.zscore"
 )
-include { UnidentifiedCalcZscores } from './CustomModules/DIMS/UnidentifiedCalcZscores.nf' params(
-    scripts_dir:"$params.scripts_dir", 
-    ppm:"$params.ppm", 
-    zscore:"$params.zscore"
-)
-include { UnidentifiedCollectPeaks } from './CustomModules/DIMS/UnidentifiedCollectPeaks.nf' params(
-    ppm:"$params.ppm"
-)
-include { UnidentifiedFillMissing } from './CustomModules/DIMS/UnidentifiedFillMissing.nf' params(
-    scripts_dir:"$params.scripts_dir", 
-    thresh:"$params.thresh", 
-    resolution:"$params.resolution", 
-    ppm:"$params.ppm"
-)
-include { UnidentifiedPeakGrouping } from './CustomModules/DIMS/UnidentifiedPeakGrouping.nf' params(
-    resolution:"$params.resolution", 
-    ppm:"$params.ppm"
-)
+// include { UnidentifiedCalcZscores } from './CustomModules/DIMS/UnidentifiedCalcZscores.nf' params(
+//     scripts_dir:"$params.scripts_dir", 
+//     ppm:"$params.ppm", 
+//     zscore:"$params.zscore"
+// )
+// include { UnidentifiedCollectPeaks } from './CustomModules/DIMS/UnidentifiedCollectPeaks.nf' params(
+//     ppm:"$params.ppm"
+// )
+// include { UnidentifiedFillMissing } from './CustomModules/DIMS/UnidentifiedFillMissing.nf' params(
+//     scripts_dir:"$params.scripts_dir", 
+//     thresh:"$params.thresh", 
+//     resolution:"$params.resolution", 
+//     ppm:"$params.ppm"
+// )
+// include { UnidentifiedPeakGrouping } from './CustomModules/DIMS/UnidentifiedPeakGrouping.nf' params(
+//     resolution:"$params.resolution", 
+//     ppm:"$params.ppm"
+// )
 include { VersionLog } from './CustomModules/Utils/VersionLog.nf'
 // include { Workflow_Export_Params } from './assets/workflow.nf'
 include { ExportParams as Workflow_ExportParams } from './assets/workflow.nf'
@@ -147,16 +148,16 @@ workflow {
     GenerateViolinPlots(GenerateExcel.out.excel_files, analysis_id)
 
     // Collect unidentified peaks
-    UnidentifiedCollectPeaks(SpectrumPeakFinding.out, PeakGrouping.out.peaks_used.collect())
+    // UnidentifiedCollectPeaks(SpectrumPeakFinding.out, PeakGrouping.out.peaks_used.collect())
 
     // Peak grouping: unidentified part
-    UnidentifiedPeakGrouping(UnidentifiedCollectPeaks.out.flatten(), AverageTechReplicates.out.pattern_files)
+    // UnidentifiedPeakGrouping(UnidentifiedCollectPeaks.out.flatten(), AverageTechReplicates.out.pattern_files)
 
     // Fill missing values in peak group list: unidentified part
-    UnidentifiedFillMissing(UnidentifiedPeakGrouping.out.grouped_unidentified, AverageTechReplicates.out.pattern_files)
+    // UnidentifiedFillMissing(UnidentifiedPeakGrouping.out.grouped_unidentified, AverageTechReplicates.out.pattern_files)
 
     // Calculate Z-scores for unidentified peak group list
-    UnidentifiedCalcZscores(UnidentifiedFillMissing.out.collect(), AverageTechReplicates.out.pattern_files)
+    // UnidentifiedCalcZscores(UnidentifiedFillMissing.out.collect(), AverageTechReplicates.out.pattern_files)
 
     // Create log files: Repository versions and Workflow params
     VersionLog(

--- a/DIMS.nf
+++ b/DIMS.nf
@@ -53,7 +53,7 @@ include { PeakFinding } from './CustomModules/DIMS/PeakFinding.nf' params(
     scripts_dir:"$params.scripts_dir"
 )
 include { PeakGrouping } from './CustomModules/DIMS/PeakGrouping.nf' params(
-    scripts_dir:"$params.scripts_dir",
+    preprocessing_scripts_dir:"$params.preprocessing_scripts_dir",
     ppm:"$params.ppm"
 )
 include { SpectrumPeakFinding } from './CustomModules/DIMS/SpectrumPeakFinding.nf'
@@ -61,24 +61,6 @@ include { SumAdducts } from './CustomModules/DIMS/SumAdducts.nf' params(
     scripts_dir:"$params.scripts_dir", 
     zscore:"$params.zscore"
 )
-// include { UnidentifiedCalcZscores } from './CustomModules/DIMS/UnidentifiedCalcZscores.nf' params(
-//     scripts_dir:"$params.scripts_dir", 
-//     ppm:"$params.ppm", 
-//     zscore:"$params.zscore"
-// )
-// include { UnidentifiedCollectPeaks } from './CustomModules/DIMS/UnidentifiedCollectPeaks.nf' params(
-//     ppm:"$params.ppm"
-// )
-// include { UnidentifiedFillMissing } from './CustomModules/DIMS/UnidentifiedFillMissing.nf' params(
-//     scripts_dir:"$params.scripts_dir", 
-//     thresh:"$params.thresh", 
-//     resolution:"$params.resolution", 
-//     ppm:"$params.ppm"
-// )
-// include { UnidentifiedPeakGrouping } from './CustomModules/DIMS/UnidentifiedPeakGrouping.nf' params(
-//     resolution:"$params.resolution", 
-//     ppm:"$params.ppm"
-// )
 include { VersionLog } from './CustomModules/Utils/VersionLog.nf'
 // include { Workflow_Export_Params } from './assets/workflow.nf'
 include { ExportParams as Workflow_ExportParams } from './assets/workflow.nf'
@@ -146,18 +128,6 @@ workflow {
 
     // Generate violin plots 
     GenerateViolinPlots(GenerateExcel.out.excel_files, analysis_id)
-
-    // Collect unidentified peaks
-    // UnidentifiedCollectPeaks(SpectrumPeakFinding.out, PeakGrouping.out.peaks_used.collect())
-
-    // Peak grouping: unidentified part
-    // UnidentifiedPeakGrouping(UnidentifiedCollectPeaks.out.flatten(), AverageTechReplicates.out.pattern_files)
-
-    // Fill missing values in peak group list: unidentified part
-    // UnidentifiedFillMissing(UnidentifiedPeakGrouping.out.grouped_unidentified, AverageTechReplicates.out.pattern_files)
-
-    // Calculate Z-scores for unidentified peak group list
-    // UnidentifiedCalcZscores(UnidentifiedFillMissing.out.collect(), AverageTechReplicates.out.pattern_files)
 
     // Create log files: Repository versions and Workflow params
     VersionLog(

--- a/DIMS.nf
+++ b/DIMS.nf
@@ -124,8 +124,7 @@ workflow {
     SpectrumPeakFinding(PeakFinding.out.collect(), AverageTechReplicates.out.pattern_files)
 
     // Peak grouping over samples: identified part
-    // PeakGrouping(HMDBparts.out.collect().flatten(), SpectrumPeakFinding.out, AverageTechReplicates.out.pattern_files)
-    PeakGrouping(HMDBparts.out.flatten(), SpectrumPeakFinding.out, AverageTechReplicates.out.pattern_files)
+    PeakGrouping(HMDBparts.out.flatten(), SpectrumPeakFinding.out)
 
     // Fill missing values in peak group list: identified part
     FillMissing(PeakGrouping.out.grouped_identified, AverageTechReplicates.out.pattern_files)


### PR DESCRIPTION
DIMS pipeline refactor PeakGrouping

The goal was to make this step of the pipeline faster, to change the peak grouping method and to add unit tests.
Peak grouping was previously done on consecutive entries in a subset of the HMDB, with 2 outputs:
- identified peak groups
- peaks used in forming identified peak groups.
The latter was then used in the Unidentified steps of the pipeline to form unidentified peak groups.
The refactored PeakGrouping has one peak group list with identified and unidentified peak groups combined. 
The unidentified steps of the pipeline have become obsolete and have been removed from DIMS.nf and DIMS.config.

main script: CustomModules/DIMS/PeakGrouping.R

- created 2 functions find_peak_groups and annotate_peak_groups
- moved functions into preprocessing folder. This folder will contain functions for all pipeline steps before GenerateExcel.
- added docstrings to preprocessing/peak_grouping_functions.R
- unit test in tests/testthat/test_peak_grouping.R

Any feedback on unit tests is welcome; still a learning curve.
  
Code can be found in /hpc/dbg_mz/development/DIMS_refactor_PeakGrouping
Output of the pipeline can be found in /hpc/dbg_mz/processed/test_refactoredPeakGrouping