### PR TITLE
Added function for e-mail with pdf

### DIFF
--- a/DIMS.config
+++ b/DIMS.config
@@ -174,7 +174,7 @@ process {
     withLabel: PeakGrouping {
         cpus = 2
         memory = { 2.GB * task.attempt }
-        time = { 80.m * task.attempt }
+        time = { 160.m * task.attempt }
     }
 
     withLabel: SpectrumPeakFinding {
@@ -186,7 +186,7 @@ process {
     withLabel: SumAdducts {
         cpus = 2
         memory = { 5.GB * task.attempt }
-        time = { 40.m * task.attempt }
+        time = { 80.m * task.attempt }
     }
 
     withLabel: ThermoRawFileParser_1_1_11 {

--- a/DIMS.nf
+++ b/DIMS.nf
@@ -86,7 +86,6 @@ include { ExportParams as Workflow_ExportParams } from './assets/workflow.nf'
 def raw_files = extractRawfilesFromDir(params.rawfiles_path)
 def analysis_id = params.outdir.split('/')[-1]
 def matrix = params.matrix
-def outdir = params.outdir
 
 workflow {
     // create init.RData file with info on technical replicates


### PR DESCRIPTION
Extra mail with PDF of TIC plots, for assessment of quality of measurements in a run, will be sent to the user before the run is finished. If unsatisfactory, individual technical replicates can be replaced and the workflow restarted.
