### PR TITLE
Feature/refactor PeakFinding

### DIFF
--- a/DIMS.config
+++ b/DIMS.config
@@ -1,5 +1,6 @@
 params {
     scripts_dir = "$projectDir/CustomModules/DIMS/Utils/" 
+    preprocessing_scripts_dir = "$projectDir/CustomModules/DIMS/preprocessing/" 
     tools_dir = "/hpc/dbg_mz/tools/db"
     hmdb_db_file = "$params.tools_dir/HMDB_V5/HMDB_V5_iso_adducts_IS.RData"
     relevance_file = "$params.tools_dir/HMDB_V5/HMDB_V5_iso_adducts_IS_rlvnc.RData"

--- a/DIMS.config
+++ b/DIMS.config
@@ -23,27 +23,10 @@ process {
         time = { 5.m * task.attempt }
     }
 
-    withLabel: AverageTechReplicates {
+    withLabel: AveragePeaks {
         cpus = 2
-        memory = { 2.GB * task.attempt }
-        time =  { 30.m * task.attempt }
-        publishDir = [
-            [
-                path: "$params.outdir/Bioinformatics",
-                mode: 'link',
-                pattern: '*.txt'
-            ],
-            [
-                path: "$params.outdir/Bioinformatics",
-                mode: 'link',
-                pattern: '*.pdf'
-            ],
-            [
-                path: "$params.outdir/Bioinformatics/RData",
-                mode: 'link',
-                pattern: '*repl_pattern.RData'
-            ]
-        ]
+        memory = { 1.GB * task.attempt }
+        time = { 60.m * task.attempt }
     }
 
     withLabel: CollectFilled {
@@ -74,6 +57,29 @@ process {
             mode = 'link'
             pattern = 'AdductSums*.RData'
         }
+    }
+
+    withLabel: EvaluateTics {
+        cpus = 2
+        memory = { 2.GB * task.attempt }
+        time =  { 10.m * task.attempt }
+        publishDir = [
+            [
+                path: "$params.outdir/Bioinformatics",
+                mode: 'link',
+                pattern: '*.txt'
+            ],
+            [
+                path: "$params.outdir/Bioinformatics",
+                mode: 'link',
+                pattern: '*.pdf'
+            ],
+            [
+                path: "$params.outdir/Bioinformatics/RData",
+                mode: 'link',
+                pattern: '*repl_pattern.RData'
+            ]
+        ]
     }
 
     withLabel: FillMissing {
@@ -176,12 +182,6 @@ process {
         cpus = 2
         memory = { 2.GB * task.attempt }
         time = { 80.m * task.attempt }
-    }
-
-    withLabel: SpectrumPeakFinding {
-        cpus = 2
-        memory = { 1.GB * task.attempt }
-        time = { 5.m * task.attempt }
     }
 
     withLabel: SumAdducts {

--- a/DIMS.config
+++ b/DIMS.config
@@ -1,12 +1,13 @@
 params {
     scripts_dir = "$projectDir/CustomModules/DIMS/Utils/" 
     preprocessing_scripts_dir = "$projectDir/CustomModules/DIMS/preprocessing/" 
+    export_scripts_dir = "$projectDir/CustomModules/DIMS/export/"
     tools_dir = "/hpc/dbg_mz/tools/db"
     hmdb_db_file = "$params.tools_dir/HMDB_V5/HMDB_V5_iso_adducts_IS.RData"
-    relevance_file = "$params.tools_dir/HMDB_V5/HMDB_V5_iso_adducts_IS_rlvnc.RData"
+    relevance_file = "$params.tools_dir/HMDB_V5/HMDB_V5_rlvnc.RData"
     hmdb_parts_files = "$params.tools_dir/HMDB_V5/hmdb_parts/"
     sst_components_file = "$params.tools_dir/SST_componenten.txt"
-    path_metabolite_groups = "$params.tools_dir/HMDB_V5/metabolite_groups"
+    path_metabolite_groups = "$params.tools_dir/metabolite_groups"
     file_ratios_metabolites = "$params.tools_dir/HMDB_V5/Ratios_between_metabolites.csv"
     file_expected_biomarkers_IEM = "$params.tools_dir/HMDB_V5/Expected_biomarkers_IEM_V5.csv"
     file_explanation = "/hpc/dbg_mz/tools/Explanation_violin_plots.txt"
@@ -128,6 +129,34 @@ process {
         ]
     }
 
+    withLabel: GenerateQCOutput {
+        cpus = 2
+        memory = { 10.GB * task.attempt }
+        time = { 10.m * task.attempt }
+        publishDir = [
+            [
+                path: "$params.outdir/Bioinformatics/RData", 
+                mode: 'link', 
+                pattern: '*.RData'
+            ],
+            [
+                path: "$params.outdir/Bioinformatics", 
+                mode: 'link', 
+                pattern: '*.txt'
+            ],
+            [
+                path: "$params.outdir/Bioinformatics", 
+                mode: 'link', 
+                pattern: '*.xlsx'
+            ],
+            [
+                path: "$params.outdir/Bioinformatics", 
+                mode: 'link', 
+                pattern: 'plots/*.png'
+            ]
+        ]
+    }
+
     withLabel: GenerateViolinPlots {
         cpus = 2
         memory = { 1.GB * task.attempt }
@@ -187,49 +216,19 @@ process {
     withLabel: PeakGrouping {
         cpus = 2
         memory = { 2.GB * task.attempt }
-        time = { 80.m * task.attempt }
+        time = { 60.m * task.attempt }
     }
 
     withLabel: SumAdducts {
         cpus = 2
         memory = { 5.GB * task.attempt }
-        time = { 40.m * task.attempt }
+        time = { 80.m * task.attempt }
     }
 
     withLabel: ThermoRawFileParser_1_1_11 {
         cpus = 2
         memory = { 2.GB * task.attempt }
         time = { 5.m * task.attempt }
-    }
-
-    withLabel: UnidentifiedCalcZscores {
-        cpus = 2
-        memory = { 10.GB * task.attempt }
-        time = { 10.m * task.attempt }
-
-        publishDir {
-            path = "$params.outdir/Bioinformatics/RData"
-            mode = 'link'
-            pattern = '*.RData'
-        }
-    }
-
-    withLabel: UnidentifiedCollectPeaks {
-        cpus = 2
-        memory = { 2.GB * task.attempt }
-        time = { 5.m * task.attempt }
-    }
-
-    withLabel: UnidentifiedFillMissing {
-        cpus = 2
-        memory = { 10.GB * task.attempt }
-        time = { 15.m * task.attempt }
-    }
-
-    withLabel: UnidentifiedPeakGrouping {
-        cpus = 2
-        memory = { 5.GB * task.attempt }
-        time = { 300.m * task.attempt }
     }
 
     withLabel: VersionLog {

--- a/DIMS.config
+++ b/DIMS.config
@@ -26,7 +26,13 @@ process {
     withLabel: AveragePeaks {
         cpus = 2
         memory = { 1.GB * task.attempt }
-        time = { 60.m * task.attempt }
+        time = { 10.m * task.attempt }
+    }
+
+    withLabel: CollectAveraged {
+        cpus = 2
+        memory = { 1.GB * task.attempt }
+        time = { 10.m * task.attempt }
     }
 
     withLabel: CollectFilled {

--- a/DIMS.nf
+++ b/DIMS.nf
@@ -16,7 +16,8 @@ include { CollectSumAdducts } from './CustomModules/DIMS/CollectSumAdducts.nf'
 include { ConvertRawFile } from './CustomModules/DIMS/ThermoRawFileParser.nf'
 include { EvaluateTics } from './CustomModules/DIMS/EvaluateTics.nf' params(
     nr_replicates:"$params.nr_replicates", 
-    matrix:"$params.matrix"
+    matrix:"$params.matrix",
+    preprocessing_scripts_dir:"$params.preprocessing_scripts_dir"
 )
 include { extractRawfilesFromDir } from './CustomModules/DIMS/Utils/RawFiles.nf'
 include { FillMissing } from './CustomModules/DIMS/FillMissing.nf' params(
@@ -104,9 +105,7 @@ workflow {
     EvaluateTics(AssignToBins.out.rdata_file.collect(),
                  AssignToBins.out.tic_txt_file.collect(),
                  MakeInit.out,
-                 params.nr_replicates, 
                  analysis_id,
-                 matrix,
                  GenerateBreaks.out.highest_mz,
                  GenerateBreaks.out.trim_params)
 
@@ -133,7 +132,7 @@ workflow {
     PeakFinding(AssignToBins.out.rdata_file.collect().flatten(), EvaluateTics.out.sample_techreps)
 
     // AveragePeaks over technical replicates on peak level
-    AveragePeaks(PeakFinding.out.collect(), ch_sample_techreps)
+    AveragePeaks(PeakFinding.out.peaklist_rdata.collect(), ch_sample_techreps)
 
     // Collect peak finding results for all samples
     CollectAveraged(AveragePeaks.out.collect())

--- a/DIMS.nf
+++ b/DIMS.nf
@@ -6,6 +6,7 @@ include { AssignToBins } from './CustomModules/DIMS/AssignToBins.nf' params(
     resolution:"$params.resolution"
 )
 include { AveragePeaks } from './CustomModules/DIMS/AveragePeaks.nf'
+include { CollectAveraged } from './CustomModules/DIMS/CollectAveraged.nf'
 include { CollectFilled } from './CustomModules/DIMS/CollectFilled.nf' params(
     scripts_dir:"$params.scripts_dir", 
     ppm:"$params.ppm", 
@@ -106,12 +107,10 @@ workflow {
     // Generate HMDB parts for parallel processing in PeakGrouping step
     HMDBparts(params.hmdb_db_file, GenerateBreaks.out.breaks)
 
-    // ConvertRawFile.out.combine(GenerateBreaks.out.breaks).view()
-
     // Assign intensities to bins (breaks) per mzML file
     AssignToBins(ConvertRawFile.out.combine(GenerateBreaks.out.breaks).combine(GenerateBreaks.out.trim_params))
 
-    // Evaluate quality of TIC plots for eacht technical replicate
+    // Evaluate quality of TIC plots for each technical replicate
     EvaluateTics(AssignToBins.out.rdata_file.collect(),
                  AssignToBins.out.tic_txt_file.collect(),
                  MakeInit.out,
@@ -121,14 +120,26 @@ workflow {
                  GenerateBreaks.out.highest_mz,
                  GenerateBreaks.out.trim_params)
 
-    // Peak finding per sample
-    PeakFinding(AssignToBins.out.rdata_file.collect().flatten().combine(GenerateBreaks.out.breaks))
+    // get info on sample with corresponding technical replicates
+    ch_sample_techreps = EvaluateTics.out.sample_techreps
+        .splitCsv(header:false)
+        .splitCsv(sep: ';')
+        .map { row ->
+            def meta = [sample_id: row[0][0], tech_reps: row[1], scanmode: row[2]]
+        }
+        .view()
+
+    // Peak finding per technical replicate
+    PeakFinding(AssignToBins.out.rdata_file.collect().flatten(), EvaluateTics.out.sample_techreps)
+
+    // AveragePeaks over technical replicates on peak level
+    AveragePeaks(PeakFinding.out.collect(), ch_sample_techreps)
 
     // Collect peak finding results for all samples
-    AveragePeaks(PeakFinding.out.collect(), EvaluateTics.out.pattern_files)
+    CollectAveraged(AveragePeaks.out.collect())
 
     // Peak grouping over samples: identified part
-    PeakGrouping(HMDBparts.out.flatten(), AveragePeaks.out, EvaluateTics.out.pattern_files)
+    PeakGrouping(HMDBparts.out.flatten(), CollectAveraged.out.averaged_peaks.collect(), EvaluateTics.out.pattern_files)
 
     // Fill missing values in peak group list: identified part
     FillMissing(PeakGrouping.out.grouped_identified, EvaluateTics.out.pattern_files)
@@ -151,16 +162,16 @@ workflow {
     GenerateViolinPlots(GenerateExcel.out.excel_files, analysis_id)
 
     // Collect unidentified peaks
-    UnidentifiedCollectPeaks(AveragePeaks.out, PeakGrouping.out.peaks_used.collect())
+    // UnidentifiedCollectPeaks(AveragePeaks.out, PeakGrouping.out.peaks_used.collect())
 
     // Peak grouping: unidentified part
-    UnidentifiedPeakGrouping(UnidentifiedCollectPeaks.out.flatten(), EvaluateTics.out.pattern_files)
+    // UnidentifiedPeakGrouping(UnidentifiedCollectPeaks.out.flatten(), EvaluateTics.out.pattern_files)
 
     // Fill missing values in peak group list: unidentified part
-    UnidentifiedFillMissing(UnidentifiedPeakGrouping.out.grouped_unidentified, EvaluateTics.out.pattern_files)
+    // UnidentifiedFillMissing(UnidentifiedPeakGrouping.out.grouped_unidentified, EvaluateTics.out.pattern_files)
 
     // Calculate Z-scores for unidentified peak group list
-    UnidentifiedCalcZscores(UnidentifiedFillMissing.out.collect(), EvaluateTics.out.pattern_files)
+    // UnidentifiedCalcZscores(UnidentifiedFillMissing.out.collect(), EvaluateTics.out.pattern_files)
 
     // Create log files: Repository versions and Workflow params
     VersionLog(

--- a/DIMS.nf
+++ b/DIMS.nf
@@ -45,6 +45,13 @@ include { GenerateViolinPlots } from './CustomModules/DIMS/GenerateViolinPlots.n
     file_explanation:"$params.file_explanation",
     file_isomers:"$params.file_isomers"
 )
+include { GenerateQCOutput } from './CustomModules/DIMS/GenerateQCOutput.nf' params(
+    analysis_id:"$params.analysis_id",
+    zscore:"$params.zscore",
+    matrix:"$params.matrix",
+    sst_components_file:"$params.sst_components_file",
+    export_scripts_dir:"$params.export_scripts_dir"
+)
 include { HMDBparts } from './CustomModules/DIMS/HMDBparts.nf' params(
     hmdb_parts_files:"$params.hmdb_parts_files", 
     standard_run:"$params.standard_run", 
@@ -57,29 +64,12 @@ include { PeakFinding } from './CustomModules/DIMS/PeakFinding.nf' params(
     preprocessing_scripts_dir:"$params.preprocessing_scripts_dir"
 )
 include { PeakGrouping } from './CustomModules/DIMS/PeakGrouping.nf' params(
+    preprocessing_scripts_dir:"$params.preprocessing_scripts_dir",
     ppm:"$params.ppm"
 )
 include { SumAdducts } from './CustomModules/DIMS/SumAdducts.nf' params(
-    scripts_dir:"$params.scripts_dir", 
+    preprocessing_scripts_dir:"$params.preprocessing_scripts_dir",
     zscore:"$params.zscore"
-)
-include { UnidentifiedCalcZscores } from './CustomModules/DIMS/UnidentifiedCalcZscores.nf' params(
-    scripts_dir:"$params.scripts_dir", 
-    ppm:"$params.ppm", 
-    zscore:"$params.zscore"
-)
-include { UnidentifiedCollectPeaks } from './CustomModules/DIMS/UnidentifiedCollectPeaks.nf' params(
-    ppm:"$params.ppm"
-)
-include { UnidentifiedFillMissing } from './CustomModules/DIMS/UnidentifiedFillMissing.nf' params(
-    scripts_dir:"$params.scripts_dir", 
-    thresh:"$params.thresh", 
-    resolution:"$params.resolution", 
-    ppm:"$params.ppm"
-)
-include { UnidentifiedPeakGrouping } from './CustomModules/DIMS/UnidentifiedPeakGrouping.nf' params(
-    resolution:"$params.resolution", 
-    ppm:"$params.ppm"
 )
 include { VersionLog } from './CustomModules/Utils/VersionLog.nf'
 // include { Workflow_Export_Params } from './assets/workflow.nf'
@@ -120,6 +110,18 @@ workflow {
                  GenerateBreaks.out.highest_mz,
                  GenerateBreaks.out.trim_params)
 
+    // Send e-mail with TIC plot PDF right after its creation
+    AverageTechReplicates.out.tic_plots_pdf.map { tic_plots_pdf ->
+        def subject = "TIC plots for run ${analysis_id}"
+        def body = "Check TIC plots for run ${analysis_id} for technical replicates that should be removed from the run"
+        sendMail(
+            to: params.email.trim(),
+            subject: subject,
+            body: body,
+            attach: tic_plots_pdf
+        )
+    }
+
     // get info on sample with corresponding technical replicates
     ch_sample_techreps = EvaluateTics.out.sample_techreps
         .splitCsv(header:false)
@@ -149,29 +151,23 @@ workflow {
 
     // Sum adducts of each metabolite per scan mode: identfied part
     SumAdducts(CollectFilled.out.filled_pgrlist, 
-               EvaluateTics.out.pattern_files, 
                HMDBparts_main.out.collect().flatten())
 
     // Collect summed adducts parts
     CollectSumAdducts(SumAdducts.out.collect())
 
     // Generate final Excel file with Z-scores on adduct sums (pos + neg)
-    GenerateExcel(CollectSumAdducts.out.collect(), CollectFilled.out.filled_pgrlist.collect(), MakeInit.out, analysis_id, params.relevance_file)
+    GenerateExcel(CollectSumAdducts.out.adductsums_combined, analysis_id, params.relevance_file)
+
+    // Generate QC rapports
+    GenerateQCOutput(GenerateExcel.out.outlist_zscores, 
+                     CollectSumAdducts.out.adductsums_scanmodes.collect(), 
+                     CollectFilled.out.filled_pgrlist.collect(), 
+                     MakeInit.out, 
+                     analysis_id)
 
     // Generate violin plots 
-    GenerateViolinPlots(GenerateExcel.out.excel_files, analysis_id)
-
-    // Collect unidentified peaks
-    // UnidentifiedCollectPeaks(AveragePeaks.out, PeakGrouping.out.peaks_used.collect())
-
-    // Peak grouping: unidentified part
-    // UnidentifiedPeakGrouping(UnidentifiedCollectPeaks.out.flatten(), EvaluateTics.out.pattern_files)
-
-    // Fill missing values in peak group list: unidentified part
-    // UnidentifiedFillMissing(UnidentifiedPeakGrouping.out.grouped_unidentified, EvaluateTics.out.pattern_files)
-
-    // Calculate Z-scores for unidentified peak group list
-    // UnidentifiedCalcZscores(UnidentifiedFillMissing.out.collect(), EvaluateTics.out.pattern_files)
+    GenerateViolinPlots(GenerateExcel.out.outlist_zscores, analysis_id)
 
     // Create log files: Repository versions and Workflow params
     VersionLog(
@@ -197,7 +193,12 @@ workflow.onComplete {
     // Send email
     if (workflow.success) {
         def subject = "DIMS Workflow Successful: ${analysis_id}"
-        sendMail(to: params.email.trim(), subject: subject, body: email_html)
+        sendMail(
+            to: params.email.trim(), 
+            subject: subject, 
+            body: email_html,
+            attach: "${params.outdir}/Bioinformatics/${analysis_id}_TICplots.pdf"
+        )
     } else {
         def subject = "DIMS Workflow Failed: ${analysis_id}"
         sendMail(to: params.email.trim(), subject: subject, body: email_html)


### PR DESCRIPTION
The PeakFinding step in the DIMS pipeline has been refactored. Instead of averaging the intensities for technical replicates and doing PeakFinding on the averages, the new method will do PeakFinding for each technical replicate. To do this, several scripts have been modified:
- DIMS.nf: 
  - AverageTechReplicates: averaging part removed, script renamed to EvaluateTics
  - extra step AveragePeaks after PeakFinding added
  - extra step CollectAveraged after AveragePeaks added
  - extra channel with information which technical replicates belong to which biological sample
  - PeakGrouping input from CollectAveraged
  - SpectrumPeakfinding step has been removed
- DIMS.config:
  - AverageTechReplicates step replaced by EvaluateTics
  - extra step CollectAveraged added  