### PR TITLE
Feature/QCinfo_in_mail

### DIFF
--- a/DIMS.config
+++ b/DIMS.config
@@ -31,7 +31,7 @@ process {
         time =  { 30.m * task.attempt }
         publishDir = [
             [
-                path: "$params.outdir/Bioinformatics",
+                path: "$params.outdir/Bioinformatics/QC",
                 mode: 'link',
                 pattern: '*.txt'
             ],
@@ -59,7 +59,7 @@ process {
                 pattern: '*.RData'
             ],
             [
-                path: "$params.outdir/Bioinformatics", 
+                path: "$params.outdir/Bioinformatics/QC", 
                 mode: 'link', 
                 pattern: '*.txt'
             ],

--- a/DIMS.nf
+++ b/DIMS.nf
@@ -28,9 +28,16 @@ include { GenerateBreaks } from './CustomModules/DIMS/GenerateBreaks.nf' params(
 )
 include { GenerateExcel } from './CustomModules/DIMS/GenerateExcel.nf' params(
     analysis_id:"$params.analysis_id", 
-    zscore:"$params.zscore",
+    zscore:"$params.zscore", 
     export_scripts_dir:"$params.export_scripts_dir",
     path_metabolite_groups:"$params.path_metabolite_groups"
+)
+include { GenerateQCOutput } from './CustomModules/DIMS/GenerateQCOutput.nf' params(
+    analysis_id:"$params.analysis_id",
+    zscore:"$params.zscore",
+    matrix:"$params.matrix",
+    sst_components_file:"$params.sst_components_file",
+    export_scripts_dir:"$params.export_scripts_dir"
 )
 include { GenerateViolinPlots } from './CustomModules/DIMS/GenerateViolinPlots.nf' params(
     analysis_id:"$params.analysis_id", 
@@ -41,13 +48,6 @@ include { GenerateViolinPlots } from './CustomModules/DIMS/GenerateViolinPlots.n
     file_expected_biomarkers_IEM:"$params.file_expected_biomarkers_IEM",
     file_explanation:"$params.file_explanation",
     file_isomers:"$params.file_isomers"
-)
-include { GenerateQCOutput } from './CustomModules/DIMS/GenerateQCOutput.nf' params(
-    analysis_id:"$params.analysis_id",
-    zscore:"$params.zscore",
-    matrix:"$params.matrix",
-    sst_components_file:"$params.sst_components_file",
-    export_scripts_dir:"$params.export_scripts_dir"
 )
 include { HMDBparts } from './CustomModules/DIMS/HMDBparts.nf' params(
     hmdb_parts_files:"$params.hmdb_parts_files", 
@@ -66,7 +66,7 @@ include { PeakGrouping } from './CustomModules/DIMS/PeakGrouping.nf' params(
 )
 include { SpectrumPeakFinding } from './CustomModules/DIMS/SpectrumPeakFinding.nf'
 include { SumAdducts } from './CustomModules/DIMS/SumAdducts.nf' params(
-    preprocessing_scripts_dir:"$params.preprocessing_scripts_dir", 
+    preprocessing_scripts_dir:"$params.preprocessing_scripts_dir",
     zscore:"$params.zscore"
 )
 include { VersionLog } from './CustomModules/Utils/VersionLog.nf'
@@ -81,7 +81,7 @@ def matrix = params.matrix
 workflow {
     // create init.RData file with info on technical replicates
     MakeInit(params.samplesheet, params.nr_replicates)
-
+/*
     // Read raw files and convert to mzML format
     ConvertRawFile(raw_files)
     
@@ -110,14 +110,12 @@ workflow {
 
     // Send e-mail with TIC plot PDF right after its creation
     AverageTechReplicates.out.tic_plots_pdf.map { tic_plots_pdf ->
-        def subject = "TIC plots for run ${analysis_id}"
-        def body = "Check TIC plots for run ${analysis_id} for technical replicates that should be removed from the run"
-        sendMail(
-            to: params.email.trim(),
-            subject: subject,
-            body: body,
-            attach: tic_plots_pdf
-        )
+         sendMail {
+              to params.email.trim()
+              attach tic_plots_pdf
+              subject "TIC plots for run ${analysis_id}"
+              body "Check TIC plots for run ${analysis_id} for technical replicates that should be removed from the run"
+         }
     }
 
     // Peak finding per sample
@@ -146,13 +144,6 @@ workflow {
     GenerateExcel(CollectSumAdducts.out.adductsums_combined, analysis_id, params.relevance_file)
 
     // Generate QC rapports
-    GenerateQCOutput(GenerateExcel.out.outlist_zscores, 
-                     CollectSumAdducts.out.adductsums_scanmodes.collect(), 
-                     CollectFilled.out.filled_pgrlist.collect(), 
-                     MakeInit.out, 
-                     analysis_id)
-
-    // Generate QC rapports
     GenerateQCOutput(GenerateExcel.out.outlist_zscores,
                      CollectSumAdducts.out.adductsums_scanmodes.collect(),
                      CollectFilled.out.filled_pgrlist.collect(),
@@ -160,8 +151,8 @@ workflow {
                      analysis_id)
 
     // Generate violin plots 
-    GenerateViolinPlots(GenerateExcel.out.outlist_zscores, analysis_id)
-
+    // GenerateViolinPlots(GenerateExcel.out.outlist_zscores, analysis_id)
+*/
     // Create log files: Repository versions and Workflow params
     VersionLog(
         Channel.of(
@@ -174,15 +165,16 @@ workflow {
 
 // Workflow completion notification
 workflow.onComplete {
+
     // HTML Template
     def template = new File("$baseDir/assets/workflow_complete.html")
-
-    def content_miss_infusions_negative = file("${params.outdir}/Bioinformatics/miss_infusions_negative.txt").text
-    def content_miss_infusions_positive = file("${params.outdir}/Bioinformatics/miss_infusions_positive.txt").text
-    def content_missing_mzrange = file("${params.outdir}/Bioinformatics/missing_mz_warning.txt").text
-    def content_missing_samples = file("${params.outdir}/Bioinformatics/sample_names_nodata.txt").text
-    def content_positive_controls = file("${params.outdir}/Bioinformatics/positive_controls_qc.txt").text
-    def content_sst_zscores = file("${params.outdir}/Bioinformatics/sst_qc.txt").text
+    def content_miss_infusions_negative = file("${params.outdir}/Bioinformatics/QC/miss_infusions_negative.txt").text
+    def content_miss_infusions_positive = file("${params.outdir}/Bioinformatics/QC/miss_infusions_positive.txt").text
+    def content_missing_mzrange = file("${params.outdir}/Bioinformatics/QC/missing_mz_warning.txt").text
+    def content_missing_samples = file("${params.outdir}/Bioinformatics/QC/sample_names_nodata.txt").text
+    def content_positive_controls = file("${params.outdir}/Bioinformatics/QC/positive_controls_warning.txt").text
+    def content_sst_zscores = file("${params.outdir}/Bioinformatics/QC/sst_qc.txt").text
+    def content_int_std_threshold = file("${params.outdir}/Bioinformatics/QC/internal_standards_below_threshold.txt").text
 
     def binding = [
         miss_infusions_negative: content_miss_infusions_negative,
@@ -191,22 +183,17 @@ workflow.onComplete {
         missing_samples: content_missing_samples,
         positive_controls: content_positive_controls,
         sst_zscores: content_sst_zscores,
+        is_threshold: content_int_std_threshold,
         runName: analysis_id,
         workflow: workflow
     ]
-
     def engine = new groovy.text.GStringTemplateEngine()
     def email_html = engine.createTemplate(template).make(binding).toString()
 
     // Send email
     if (workflow.success) {
         def subject = "DIMS Workflow Successful: ${analysis_id}"
-        sendMail(
-            to: params.email.trim(), 
-            subject: subject, 
-            body: email_html,
-            attach: "${params.outdir}/Bioinformatics/${analysis_id}_TICplots.pdf"
-        )
+        sendMail(to: params.email.trim(), subject: subject, body: email_html, attach: "${params.outdir}/Bioinformatics/${analysis_id}_TICplots.pdf")
     } else {
         def subject = "DIMS Workflow Failed: ${analysis_id}"
         sendMail(to: params.email.trim(), subject: subject, body: email_html)

--- a/DIMS.nf
+++ b/DIMS.nf
@@ -81,7 +81,7 @@ def matrix = params.matrix
 workflow {
     // create init.RData file with info on technical replicates
     MakeInit(params.samplesheet, params.nr_replicates)
-/*
+
     // Read raw files and convert to mzML format
     ConvertRawFile(raw_files)
     
@@ -151,8 +151,8 @@ workflow {
                      analysis_id)
 
     // Generate violin plots 
-    // GenerateViolinPlots(GenerateExcel.out.outlist_zscores, analysis_id)
-*/
+    GenerateViolinPlots(GenerateExcel.out.outlist_zscores, analysis_id)
+
     // Create log files: Repository versions and Workflow params
     VersionLog(
         Channel.of(
@@ -193,9 +193,18 @@ workflow.onComplete {
     // Send email
     if (workflow.success) {
         def subject = "DIMS Workflow Successful: ${analysis_id}"
-        sendMail(to: params.email.trim(), subject: subject, body: email_html, attach: "${params.outdir}/Bioinformatics/${analysis_id}_TICplots.pdf")
+        sendMail(
+            to: params.email.trim(), 
+            subject: subject, 
+            body: email_html, 
+            attach: "${params.outdir}/Bioinformatics/${analysis_id}_TICplots.pdf"
+        )
     } else {
         def subject = "DIMS Workflow Failed: ${analysis_id}"
-        sendMail(to: params.email.trim(), subject: subject, body: email_html)
+        sendMail(
+            to: params.email.trim(), 
+            subject: subject, 
+            body: email_html
+        )
     }
 }

--- a/DIMS.nf
+++ b/DIMS.nf
@@ -144,6 +144,13 @@ workflow {
     // Generate final Excel file with Z-scores on adduct sums (pos + neg)
     GenerateExcel(CollectSumAdducts.out.collect(), CollectFilled.out.filled_pgrlist.collect(), MakeInit.out, analysis_id, params.relevance_file)
 
+    // Generate QC rapports
+    GenerateQCOutput(GenerateExcel.out.outlist_zscores,
+                     CollectSumAdducts.out.adductsums_scanmodes.collect(),
+                     CollectFilled.out.filled_pgrlist.collect(),
+                     MakeInit.out,
+                     analysis_id)
+
     // Generate violin plots 
     GenerateViolinPlots(GenerateExcel.out.excel_files, analysis_id)
 
@@ -173,10 +180,25 @@ workflow {
 workflow.onComplete {
     // HTML Template
     def template = new File("$baseDir/assets/workflow_complete.html")
+
+    def content_miss_infusions_negative = file("${params.outdir}/Bioinformatics/miss_infusions_negative.txt").text
+    def content_miss_infusions_positive = file("${params.outdir}/Bioinformatics/miss_infusions_positive.txt").text
+    def content_missing_mzrange = file("${params.outdir}/Bioinformatics/missing_mz_warning.txt").text
+    def content_missing_samples = file("${params.outdir}/Bioinformatics/sample_names_nodata.txt").text
+    def content_positive_controls = file("${params.outdir}/Bioinformatics/positive_controls_qc.txt").text
+    def content_sst_zscores = file("${params.outdir}/Bioinformatics/sst_qc.txt").text
+
     def binding = [
+        miss_infusions_negative: content_miss_infusions_negative,
+        miss_infusions_positive: content_miss_infusions_positive,
+        missing_mzrange: content_missing_mzrange,
+        missing_samples: content_missing_samples,
+        positive_controls: content_positive_controls,
+        sst_zscores: content_sst_zscores,
         runName: analysis_id,
         workflow: workflow
     ]
+
     def engine = new groovy.text.GStringTemplateEngine()
     def email_html = engine.createTemplate(template).make(binding).toString()
 

--- a/assets/workflow_complete.html
+++ b/assets/workflow_complete.html
@@ -17,16 +17,22 @@
     <div style="color: #3c763d; background-color: #dff0d8; border-color: #d6e9c6; padding: 15px; margin-bottom: 20px; border: 1px solid transparent; border-radius: 4px;">
         Execution completed successfully!
     </div>
-    <% } else { %>
-    <div style="color: #a94442; background-color: #f2dede; border-color: #ebccd1; padding: 15px; margin-bottom: 20px; border: 1px solid transparent; border-radius: 4px;">
-        <h4 style="margin-top:0; color: inherit;">Execution completed unsuccessfully!</h4>
-        <p>The exit status of the task that caused the workflow execution to fail was: <code>${workflow.exitStatus != null ? workflow.exitStatus : '-'}</code>.</p>
-        <p>The full error message was:</p>
-        <pre style="white-space: pre-wrap; overflow: visible; margin-bottom: 0;">${workflow.errorReport ?: 'n/a'}</pre>
-    </div>
-    <% } %>
 
-        <h1>QC: </h1>
+    <%
+        def stripQuotes = { v ->
+            if (v == null) return ''
+            v.replaceAll(/^"(.*)"$/, '$1')
+        }
+
+        
+        def splitTsvLine = { line ->
+            if (!line) return []
+            line.split(/\t/, -1).collect { stripQuotes(it) }
+        }
+    %>
+
+    <h2>QC output</h2>
+
     <h3>Missing infusions in negative scan mode</h3>
     <p>${miss_infusions_negative}</p>
 
@@ -42,8 +48,51 @@
     <h3>Z-scores for positive control samples</h3>
     <p>${positive_controls}</p>
 
-    <h3>SST componenet with Z-score below 2</h3>
+    <h3>SST components with Z-score below 2</h3>
     <p>${sst_zscores}</p>
+
+    <h3>Internal standards with intensity below threshold</h3>
+
+    <%
+        def lines = (is_threshold ?: '').trim().readLines()
+
+
+        if (lines && lines.size() > 0) {
+            def headers = splitTsvLine(lines[0])
+            def rows = lines.tail().findAll { it?.trim() }.collect { splitTsvLine(it) }
+    %>
+
+        <table border="1" style="border-collapse:collapse; width:100%; padding: 4px;">
+        <thead>
+            <tr>
+            <% headers.each { h -> %>
+                <th><%= h %></th>
+            <% } %>
+            </tr>
+        </thead>
+        <tbody>
+            <% rows.each { row -> %>
+            <tr>
+                <% row.each { cell -> %>
+                    <td><%= cell %></td>
+                <% } %>
+            </tr>
+            <% } %>
+        </tbody>
+        </table>
+    <% } else { %>
+        <p><em>Geen data gevonden in <code>internal_standards_below_threshold.txt</code>.</em></p>
+    <% } %>
+
+    <% } else { %>
+    <div style="color: #a94442; background-color: #f2dede; border-color: #ebccd1; padding: 15px; margin-bottom: 20px; border: 1px solid transparent; border-radius: 4px;">
+        <h4 style="margin-top:0; color: inherit;">Execution completed unsuccessfully!</h4>
+        <p>The exit status of the task that caused the workflow execution to fail was: <code>${workflow.exitStatus != null ? workflow.exitStatus : '-'}</code>.</p>
+        <p>The full error message was:</p>
+        <pre style="white-space: pre-wrap; overflow: visible; margin-bottom: 0;">${workflow.errorReport ?: 'n/a'}</pre>
+    </div>
+    <% } %>
+
 
     <h2>Execution summary</h2>
 

--- a/assets/workflow_complete.html
+++ b/assets/workflow_complete.html
@@ -19,9 +19,9 @@
     </div>
 
     <%
-        def stripQuotes = { v ->
-            if (v == null) return ''
-            v.replaceAll(/^"(.*)"$/, '$1')
+        def stripQuotes = { value ->
+            if (value == null) return ''
+            value.replaceAll(/^"(.*)"$/, '$1')
         }
 
         
@@ -60,8 +60,8 @@
         <table border="1" style="border-collapse:collapse; width:100%; padding: 4px;">
         <thead>
             <tr>
-            <% sstheaders.each { h -> %>
-                <th><%= h %></th>
+            <% sstheaders.each { header -> %>
+                <th><%= header %></th>
             <% } %>
             </tr>
         </thead>
@@ -92,8 +92,8 @@
         <table border="1" style="border-collapse:collapse; width:100%; padding: 4px;">
         <thead>
             <tr>
-            <% headers.each { h -> %>
-                <th><%= h %></th>
+            <% headers.each { header -> %>
+                <th><%= header %></th>
             <% } %>
             </tr>
         </thead>

--- a/assets/workflow_complete.html
+++ b/assets/workflow_complete.html
@@ -26,6 +26,25 @@
     </div>
     <% } %>
 
+        <h1>QC: </h1>
+    <h3>Missing infusions in negative scan mode</h3>
+    <p>${miss_infusions_negative}</p>
+
+    <h3>Missing infusions in positive scan mode</h3>
+    <p>${miss_infusions_positive}</p>
+
+    <h3>Missing samples (all technical replicates rejected)</h3>
+    <p>${missing_samples}</p>
+
+    <h3>Missing mass ranges</h3>
+    <p>${missing_mzrange}</p>
+
+    <h3>Z-scores for positive control samples</h3>
+    <p>${positive_controls}</p>
+
+    <h3>SST componenet with Z-score below 2</h3>
+    <p>${sst_zscores}</p>
+
     <h2>Execution summary</h2>
 
     <table cellpadding="4" >

--- a/assets/workflow_complete.html
+++ b/assets/workflow_complete.html
@@ -49,13 +49,40 @@
     <p>${positive_controls}</p>
 
     <h3>SST components with Z-score below 2</h3>
-    <p>${sst_zscores}</p>
+    <%
+        def sstlines = (sst_zscores ?: '').trim().readLines()
+
+        if (sstlines && sstlines.size() > 0) {
+            def sstheaders = splitTsvLine(sstlines[0])
+            def sstrows = sstlines.tail().findAll { it?.trim() }.collect { splitTsvLine(it) }
+    %>
+
+        <table border="1" style="border-collapse:collapse; width:100%; padding: 4px;">
+        <thead>
+            <tr>
+            <% sstheaders.each { h -> %>
+                <th><%= h %></th>
+            <% } %>
+            </tr>
+        </thead>
+        <tbody>
+            <% sstrows.each { row -> %>
+            <tr>
+                <% row.each { cell -> %>
+                    <td><%= cell %></td>
+                <% } %>
+            </tr>
+            <% } %>
+        </tbody>
+        </table>
+    <% } else { %>
+        <p>${sst_zscores}</p>
+    <% } %>
 
     <h3>Internal standards with intensity below threshold</h3>
 
     <%
         def lines = (is_threshold ?: '').trim().readLines()
-
 
         if (lines && lines.size() > 0) {
             def headers = splitTsvLine(lines[0])
@@ -81,7 +108,7 @@
         </tbody>
         </table>
     <% } else { %>
-        <p><em>Geen data gevonden in <code>internal_standards_below_threshold.txt</code>.</em></p>
+        <p>${is_threshold}</p>
     <% } %>
 
     <% } else { %>


### PR DESCRIPTION
Deze feature zorgt ervoor dat er extra QC informatie vanuit de DIMS pipeline in de eindmail komt, zodat de gebruiker in 1 oogopslag de kwaliteit van de run kan beoordelen. 
- DIMS.nf is aangepast om de QC txt bestanden in te lezen als content
- assets/workflow_complete.html is aangepast om deze txt info in de mail te stoppen. 
In het geval van de SST componenten en de interne standaarden wordt deze weergegeven in de vorm van een tabel, de overige info is gewoon een string.
